### PR TITLE
Add type hinting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,16 @@ The schema definition is converted into column level expectations (expect_column
 
 
 # Known exceptions
-The functions can run on Databricks using a Personal Compute Cluster or using a Job Cluster. Using a Shared Compute Cluster will results in an error, as it does not have the permissions that Great Expectations requires.
+- The functions can run on Databricks using a Personal Compute Cluster or using a Job Cluster. 
+Using a Shared Compute Cluster will result in an error, as it does not have the permissions that Great Expectations requires.
+
+- Since this project requires Python >= 3.10, the use of Databricks Runtime (DBR) >= 13.3 is needed 
+([click](https://docs.databricks.com/en/release-notes/runtime/13.3lts.html#system-environment)). 
+Older versions of DBR will result in errors upon install of the `dq-suite-amsterdam` library.
 
 
 # Contributing to this library
-See the separate [developers readme](src/Readme-dev.md).
+See the separate [developers' readme](src/Readme-dev.md).
 
 
 # Updates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dq-suite-amsterdam"
-version = "0.6.2"
+version = "0.6.3"
 authors = [
   { name="Arthur Kordes", email="a.kordes@amsterdam.nl" },
   { name="Aysegul Cayir Aydar", email="a.cayiraydar@amsterdam.nl" },

--- a/src/Readme-dev.md
+++ b/src/Readme-dev.md
@@ -1,7 +1,12 @@
 # Requirements
-Both app and dev dependencies from [pyproject.toml](../pyproject.toml) need to be installed in the environment.
+Both app and dev dependencies from [pyproject.toml](../pyproject.toml) need to be installed 
+in the environment. To install app/core dependencies, use
 ``` shell
-pip install .[dev] # some shells don't recognize .[dev] and need '.[dev]' 
+pip install . 
+```
+To also install the (optional) dev dependencies, use
+``` shell
+pip install .[dev]  # some shells don't recognize .[dev] and need '.[dev]' 
 ```
 
 

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -1,8 +1,9 @@
 import json
+from typing import List
 
 import great_expectations as gx
 from great_expectations.checkpoint import Checkpoint
-from pyspark.sql import SparkSession
+from pyspark.sql import DataFrame, SparkSession
 
 from src.dq_suite.input_helpers import (
     expand_input,
@@ -20,23 +21,22 @@ from src.dq_suite.output_transformations import (
 
 
 def df_check(
-    dfs: list,
+    dfs: List[DataFrame],
     dq_rules: str,
     catalog_name: str,
     check_name: str,
     spark: SparkSession,
-):
+) -> None:
     """
     Function takes DataFrame instances with specified Data Quality rules.
     and returns a JSON string with the DQ results with different dataframes in results dict,
     and returns different dfs as specified using Data Quality rules
 
     :param dfs: A list of DataFrame instances to process.
-    :type dfs: list[DataFrame]
     :param dq_rules: JSON string containing the Data Quality rules to be evaluated.
-    :type dq_rules: str
+    :param catalog_name: [explanation goes here]
     :param check_name: Name of the run for reference purposes.
-    :type check_name: str
+    :param spark: [explanation goes here]
     """
 
     name = check_name

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -1,4 +1,3 @@
-import json
 from typing import List
 
 import great_expectations as gx
@@ -9,7 +8,7 @@ from src.dq_suite.input_helpers import (
     expand_input,
     fetch_schema_from_github,
     generate_dq_rules_from_schema,
-    validate_dqrules,
+    validate_and_load_dqrules,
 )
 from src.dq_suite.output_transformations import (
     create_bronattribute,
@@ -41,8 +40,7 @@ def df_check(
 
     name = check_name
 
-    validate_dqrules(dq_rules)
-    initial_rule_json = json.loads(dq_rules)
+    initial_rule_json = validate_and_load_dqrules(dq_rules)
     rule_json = expand_input(initial_rule_json)
 
     # Generate DQ rules from schema

--- a/src/dq_suite/input_helpers.py
+++ b/src/dq_suite/input_helpers.py
@@ -1,6 +1,6 @@
 import json
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import requests
 from pyspark.sql import SparkSession
@@ -13,16 +13,15 @@ class Rule:
     """
 
     rule_name: str  # Name of the GX expectation
-    parameters: List[Dict]  # Collection of parameters required for
+    parameters: List[Dict[str, Any]]  # Collection of parameters required for
     # evaluating the expectation
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> str | List[Dict[str, Any]] | None:
         if key == "rule_name":
             return self.rule_name
         elif key == "parameters":
             return self.parameters
-        else:
-            raise KeyError(key)
+        raise KeyError(key)
 
 
 @dataclass()
@@ -35,18 +34,17 @@ class RulesDict:
     table_name: str
     rules_list: List[Rule]
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> str | List[Rule] | None:
         if key == "unique_identifier":
             return self.unique_identifier
         elif key == "table_name":
             return self.table_name
         elif key == "rules_list":
             return self.rules_list
-        else:
-            raise KeyError(key)
+        raise KeyError(key)
 
 
-RulesDictList = List[RulesDict]
+RulesDictList = List[RulesDict]  # a list of dictionaries containing DQ rules
 
 
 @dataclass()
@@ -57,23 +55,13 @@ class DataQualityRulesDict:
 
     tables: RulesDictList
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> RulesDictList | None:
         if key == "tables":
             return self.tables
-        else:
-            raise KeyError(key)
+        raise KeyError(key)
 
 
-@dataclass()
-class SchemaDict:
-    """
-    info goes here
-    """
-
-    # TODO: implement
-
-
-def validate_dqrules(dq_rules: str) -> None:
+def validate_and_load_dqrules(dq_rules: str) -> Any | None:
     """
     Function validates the input JSON
 
@@ -81,7 +69,7 @@ def validate_dqrules(dq_rules: str) -> None:
     """
 
     try:
-        json.loads(dq_rules)
+        return json.loads(dq_rules)
 
     except json.JSONDecodeError as e:
         error_message = str(e)
@@ -123,16 +111,13 @@ def expand_input(rule_json: DataQualityRulesDict) -> DataQualityRulesDict:
     return rule_json
 
 
-def export_schema(dataset: str, spark: SparkSession):
+def export_schema(dataset: str, spark: SparkSession) -> str:
     """
     Function exports a schema from Unity Catalog to be used by the Excel input form
 
     :param dataset: The name of the required dataset
-    :type dataset: str
     :param spark: The current SparkSession required for querying
-    :type spark: SparkSession
     :return: schema_json: A JSON string with the schema of the required dataset
-    :rtype: str
     """
 
     table_query = """
@@ -173,50 +158,44 @@ def export_schema(dataset: str, spark: SparkSession):
     return json.dumps(output_dict)
 
 
-def fetch_schema_from_github(dq_rules: DataQualityRulesDict) -> SchemaDict:
+def fetch_schema_from_github(dq_rules: DataQualityRulesDict) -> Dict[str, Any]:
     """
     Function fetches a schema from the Github Amsterdam schema using the dq_rules.
 
     :param dq_rules: A dictionary with all DQ configuration.
-    :type dq_rules: dict
-    :return: schemas: A dictionary with the schema of the required tables.
-    :rtype: dict
+    :return: schema_dict: A dictionary with the schema of the required tables.
     """
 
-    schemas = {}
+    schema_dict = {}
     for table in dq_rules["tables"]:
         if "validate_table_schema_url" in table:
-            url = table["validate_table_schema_url"]
+            url = table["validate_table_schema_url"]  # TODO: validate URL
             r = requests.get(url)
             schema = json.loads(r.text)
-            schemas[table["table_name"]] = schema
+            schema_dict[table["table_name"]] = schema
 
-    return schemas
+    return schema_dict
 
 
-# TODO: fix return type
 def generate_dq_rules_from_schema(
-    dq_rules: DataQualityRulesDict, schemas: SchemaDict
-) -> dict:
+    dq_rules_dict: DataQualityRulesDict, schema_dict: Dict[str, Any]
+) -> DataQualityRulesDict:
     """
-    Function adds  expect_column_values_to_be_of_type rule for each column of
+    Function adds expect_column_values_to_be_of_type rule for each column of
     tables having schema_id and schema_url in dq_rules.
 
-    :param dq_rules: A dictionary with all DQ configuration.
-    :type dq_rules: dict
-    :param schemas: A dictionary with the schemas of the required tables.
-    : type: dict
-    :return: dq_rules: A dictionary with all DQ configuration.
-    :rtype: dict
+    :param dq_rules_dict: A dictionary with all DQ configuration.
+    :param schema_dict: A dictionary with the schemas of the required tables.
+    :return: A dictionary with all DQ configuration.
     """
 
-    for table in dq_rules["tables"]:
+    for table in dq_rules_dict["tables"]:
         if "validate_table_schema" in table:
             schema_id = table["validate_table_schema"]
             table_name = table["table_name"]
 
-            if table_name in schemas:
-                schema = schemas[table_name]
+            if table_name in schema_dict:
+                schema = schema_dict[table_name]
                 if "schema" in schema and "properties" in schema["schema"]:
                     schema_columns = schema["schema"][
                         "properties"
@@ -247,4 +226,4 @@ def generate_dq_rules_from_schema(
                         }
                         table["rules"].append(rule)
 
-    return dq_rules
+    return dq_rules_dict

--- a/src/dq_suite/input_helpers.py
+++ b/src/dq_suite/input_helpers.py
@@ -22,7 +22,7 @@ class Rule:
         elif key == "parameters":
             return self.parameters
         else:
-            raise KeyError
+            raise KeyError(key)
 
 
 @dataclass()
@@ -43,7 +43,7 @@ class RulesDict:
         elif key == "rules_list":
             return self.rules_list
         else:
-            raise KeyError
+            raise KeyError(key)
 
 
 RulesDictList = List[RulesDict]

--- a/src/dq_suite/input_helpers.py
+++ b/src/dq_suite/input_helpers.py
@@ -9,7 +9,7 @@ from pyspark.sql import SparkSession
 @dataclass()
 class Rule:
     """
-    Groups together the name of the GX validation rule, together with the
+    Groups the name of the GX validation rule together with the
     parameters required to apply this rule.
     """
 
@@ -28,9 +28,9 @@ class Rule:
 @dataclass()
 class RulesDict:
     """
-    Groups together a list of Rules, together with the name of the table
+    Groups a list of Rule-objects together with the name of the table
     these rules are to be applied to, as well as a unique identifier used for
-    uniquely identifying outliers.
+    identifying outliers.
     """
 
     unique_identifier: str  # TODO: List[str] for more complex keys?

--- a/src/dq_suite/input_helpers.py
+++ b/src/dq_suite/input_helpers.py
@@ -209,6 +209,7 @@ def generate_dq_rules_from_schema(
                             break
 
                 if "schema" in schema_columns:
+                    # TODO/check: what if schema_columns does not exist?
                     del schema_columns["schema"]
 
                 for column, properties in schema_columns.items():
@@ -218,12 +219,10 @@ def generate_dq_rules_from_schema(
                             rule_type = "IntegerType"
                         else:
                             rule_type = column_type.capitalize() + "Type"
-                        rule = {
-                            "rule_name": "expect_column_values_to_be_of_type",
-                            "parameters": [
-                                {"column": column, "type_": rule_type}
-                            ],
-                        }
+                        rule = Rule(
+                            rule_name="expect_column_values_to_be_of_type",
+                            parameters=[{"column": column, "type_": rule_type}],
+                        )
                         table["rules"].append(rule)
 
     return dq_rules_dict

--- a/src/dq_suite/input_helpers.py
+++ b/src/dq_suite/input_helpers.py
@@ -9,7 +9,8 @@ from pyspark.sql import SparkSession
 @dataclass()
 class Rule:
     """
-    info goes here
+    Groups together the name of the GX validation rule, together with the
+    parameters required to apply this rule.
     """
 
     rule_name: str  # Name of the GX expectation
@@ -27,7 +28,9 @@ class Rule:
 @dataclass()
 class RulesDict:
     """
-    info goes here
+    Groups together a list of Rules, together with the name of the table
+    these rules are to be applied to, as well as a unique identifier used for
+    uniquely identifying outliers.
     """
 
     unique_identifier: str  # TODO: List[str] for more complex keys?
@@ -49,10 +52,6 @@ RulesDictList = List[RulesDict]  # a list of dictionaries containing DQ rules
 
 @dataclass()
 class DataQualityRulesDict:
-    """
-    info goes here
-    """
-
     tables: RulesDictList
 
     def __getitem__(self, key) -> RulesDictList | None:

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -12,7 +12,7 @@ def extract_dq_validatie_data(
     [insert explanation here]
 
     :param df_name: Name of the tables
-    :param dq_result:  # TODO: add dataclass
+    :param dq_result:  # TODO: add dataclass?
     :param catalog_name:
     :param spark:
     """
@@ -52,7 +52,7 @@ def extract_dq_validatie_data(
 
 def extract_dq_afwijking_data(
     df_name: str,
-    dq_result: dict,  # TODO: add dataclass
+    dq_result: dict,  # TODO: add dataclass?
     df: DataFrame,
     unique_identifier: str,
     catalog_name: str,

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -5,7 +5,7 @@ from pyspark.sql.functions import col
 
 def extract_dq_validatie_data(
     df_name, dq_result, catalog_name, spark: SparkSession
-):
+) -> None:
     """
     Function takes a json dq_rules,and a string df_name and returns dataframe.
 
@@ -47,12 +47,14 @@ def extract_dq_validatie_data(
         spark.createDataFrame(df_dq_validatie).write.mode("append").option(
             "overwriteSchema", "true"
         ).saveAsTable(f"{catalog_name}.dataquality.validatie")
-    return
+    else:
+        # TODO: implement (raise error?)
+        pass
 
 
 def extract_dq_afwijking_data(
     df_name, dq_result, df, unique_identifier, catalog_name, spark: SparkSession
-):
+) -> None:
     """
     Function takes a json dq_rules and a string df_name and returns a DataFrame.
 
@@ -116,10 +118,12 @@ def extract_dq_afwijking_data(
         spark.createDataFrame(df_dq_afwijking).write.mode("append").option(
             "overwriteSchema", "true"
         ).saveAsTable(f"{catalog_name}.dataquality.afwijking")
-    return
+    else:
+        # TODO: implement (raise error?)
+        pass
 
 
-def create_brontabel(dq_rules, catalog_name, spark: SparkSession):
+def create_brontabel(dq_rules, catalog_name, spark: SparkSession) -> None:
     """
     Function takes the table name and their unique identifier from the provided Data Quality rules
     to create a DataFrame containing this metadata.
@@ -139,10 +143,9 @@ def create_brontabel(dq_rules, catalog_name, spark: SparkSession):
     spark.createDataFrame(df_brontable).write.mode("append").option(
         "overwriteSchema", "true"
     ).saveAsTable(f"{catalog_name}.dataquality.brontabel")
-    return
 
 
-def create_bronattribute(dq_rules, catalog_name, spark: SparkSession):
+def create_bronattribute(dq_rules, catalog_name, spark: SparkSession) -> None:
     """
     This function takes attributes/columns for each table specified in the Data Quality rules and creates a DataFrame containing these attribute details.
 
@@ -177,10 +180,9 @@ def create_bronattribute(dq_rules, catalog_name, spark: SparkSession):
     spark.createDataFrame(df_bronattribuut).write.mode("append").option(
         "overwriteSchema", "true"
     ).saveAsTable(f"{catalog_name}.dataquality.bronattribuut")
-    return
 
 
-def create_dqRegel(dq_rules, catalog_name, spark: SparkSession):
+def create_dqRegel(dq_rules, catalog_name, spark: SparkSession) -> None:
     """
     Function extracts information about Data Quality rules applied to each attribute/column for tables specified in the Data Quality rules and creates a DataFrame containing these rule details.
 
@@ -208,4 +210,3 @@ def create_dqRegel(dq_rules, catalog_name, spark: SparkSession):
     spark.createDataFrame(df_dqRegel).write.mode("append").option(
         "overwriteSchema", "true"
     ).saveAsTable(f"{catalog_name}.dataquality.regel")
-    return

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -1,22 +1,20 @@
 import pandas as pd
-from pyspark.sql import SparkSession
+from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col
+
+from src.dq_suite.input_helpers import DataQualityRulesDict
 
 
 def extract_dq_validatie_data(
-    df_name, dq_result, catalog_name, spark: SparkSession
+    df_name: str, dq_result: dict, catalog_name: str, spark: SparkSession
 ) -> None:
     """
-    Function takes a json dq_rules,and a string df_name and returns dataframe.
+    [insert explanation here]
 
-    :param df_dq_validatie: A df containing the valid result
-    :type df: DataFrame
-    :param dq_rules: A JSON string containing the Data Quality rules to be evaluated
-    :type dq_rules: str
     :param df_name: Name of the tables
-    :type df_name: str
-    :return: A table df with the valid result DQ results, parsed from the extract_dq_validatie_data output
-    :rtype: df.
+    :param dq_result:  # TODO: add dataclass
+    :param catalog_name:
+    :param spark:
     """
 
     # Access run_time attribute
@@ -53,18 +51,22 @@ def extract_dq_validatie_data(
 
 
 def extract_dq_afwijking_data(
-    df_name, dq_result, df, unique_identifier, catalog_name, spark: SparkSession
+    df_name: str,
+    dq_result: dict,  # TODO: add dataclass
+    df: DataFrame,
+    unique_identifier: str,
+    catalog_name: str,
+    spark: SparkSession,
 ) -> None:
     """
-    Function takes a json dq_rules and a string df_name and returns a DataFrame.
+    [insert explanation here]
 
-    :param df_dq_validatie: A DataFrame containing the invalid (deviated) result
-    :type df: DataFrame
     :param df_name: Name of the tables
-    :type df_name: str
-    : param unique_identifier: int comes from dq_rules
-    :type unique_identifier: int
-    :rtype: DataFrame
+    :param dq_result:
+    :param df: A DataFrame containing the invalid (deviated) result
+    :param unique_identifier:
+    :param catalog_name:
+    :param spark:
     """
     # Extracting information from the JSON
     run_time = dq_result["meta"]["run_id"].run_time  # Access run_time attribute
@@ -82,7 +84,7 @@ def extract_dq_afwijking_data(
             "partial_unexpected_list", []
         )
         for value in afwijkende_attribuut_waarde:
-            if value == None:
+            if value is None:
                 filtered_df = df.filter(col(attribute).isNull())
                 ids = (
                     filtered_df.select(unique_identifier)
@@ -123,16 +125,19 @@ def extract_dq_afwijking_data(
         pass
 
 
-def create_brontabel(dq_rules, catalog_name, spark: SparkSession) -> None:
+def create_brontabel(
+    dq_rules_dict: DataQualityRulesDict, catalog_name: str, spark: SparkSession
+) -> None:
     """
-    Function takes the table name and their unique identifier from the provided Data Quality rules
-    to create a DataFrame containing this metadata.
+    Function takes the table name and their unique identifier from the provided
+    Data Quality rules to create a DataFrame containing this metadata.
 
-    :param name: dq_rules
-    :type name: str
+    :param dq_rules_dict:
+    :param catalog_name:
+    :param spark:
     """
     extracted_data = []
-    for param in dq_rules["tables"]:
+    for param in dq_rules_dict["tables"]:
         name = param["table_name"]
         unique_identifier = param["unique_identifier"]
         extracted_data.append(
@@ -145,18 +150,20 @@ def create_brontabel(dq_rules, catalog_name, spark: SparkSession) -> None:
     ).saveAsTable(f"{catalog_name}.dataquality.brontabel")
 
 
-def create_bronattribute(dq_rules, catalog_name, spark: SparkSession) -> None:
+def create_bronattribute(
+    dq_rules_dict: DataQualityRulesDict, catalog_name: str, spark: SparkSession
+) -> None:
     """
-    This function takes attributes/columns for each table specified in the Data Quality rules and creates a DataFrame containing these attribute details.
+    This function takes attributes/columns for each table specified in the Data
+    Quality rules and creates a DataFrame containing these attribute details.
 
-    :param dq_rules: Data Quality rules
-    :type dq_rules: dict
-    :return: df_bronattribuut
-    :rtype: DataFrame
+    :param dq_rules_dict:
+    :param catalog_name:
+    :param spark:
     """
     extracted_data = []
     used_ids = set()  # To keep track of used IDs
-    for param in dq_rules["tables"]:
+    for param in dq_rules_dict["tables"]:
         bron_tabel = param["table_name"]
         for rule in param["rules"]:
             parameters = rule.get("parameters", [])
@@ -182,15 +189,20 @@ def create_bronattribute(dq_rules, catalog_name, spark: SparkSession) -> None:
     ).saveAsTable(f"{catalog_name}.dataquality.bronattribuut")
 
 
-def create_dqRegel(dq_rules, catalog_name, spark: SparkSession) -> None:
+def create_dqRegel(
+    dq_rules_dict: DataQualityRulesDict, catalog_name: str, spark: SparkSession
+) -> None:
     """
-    Function extracts information about Data Quality rules applied to each attribute/column for tables specified in the Data Quality rules and creates a DataFrame containing these rule details.
+    Function extracts information about Data Quality rules applied to each
+    attribute/column for tables specified in the Data Quality rules and creates
+    a DataFrame containing these rule details.
 
-    :param dq_rules:
-    :type dq_rules: str
+    :param dq_rules_dict:
+    :param catalog_name:
+    :param spark:
     """
     extracted_data = []
-    for param in dq_rules["tables"]:
+    for param in dq_rules_dict["tables"]:
         bron_tabel = param["table_name"]
         for rule in param["rules"]:
             rule_name = rule["rule_name"]


### PR DESCRIPTION
This PR attempts to add more readability/clarity to the code by adding type hints in all function definitions. The main changes are as follows:
- Introduced dataclasses to describe the contents of a DQ rules json file
- Slightly modified `validate_and_load_dqrules` so `json.loads` does not have to be called twice in a row
- Renamed parameters with suffix `_dict` to explicitly indicate a dictionary
- Removed type descriptions from docstrings (as these are now captured by the type hints)
- Slightly modified readme and readme-dev