### PR TITLE
Add write to unity catalog function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dq-suite-amsterdam"
-version = "0.7.0"
+version = "0.7.2"
 authors = [
   { name="Arthur Kordes", email="a.kordes@amsterdam.nl" },
   { name="Aysegul Cayir Aydar", email="a.cayiraydar@amsterdam.nl" },

--- a/scripts/data_quality_tables.sql
+++ b/scripts/data_quality_tables.sql
@@ -4,11 +4,11 @@
 
 -- COMMAND ----------
 
-create schema if not exists ${catalog}.dataquality
+create schema if not exists ${catalog}.data_quality
 
 -- COMMAND ----------
 
-CREATE TABLE IF NOT EXISTS ${catalog}.dataquality.regel (
+CREATE TABLE IF NOT EXISTS ${catalog}.data_quality.regel (
   `regelId` STRING,
   `bronTabelId` STRING,
   `bronAttribuutId` STRING)
@@ -24,7 +24,7 @@ TBLPROPERTIES (
 
 -- COMMAND ----------
 
-CREATE TABLE IF NOT EXISTS ${catalog}.dataquality.bronattribuut (
+CREATE TABLE IF NOT EXISTS ${catalog}.data_quality.bronattribuut (
   name STRING,
   `bronAttribuutId` STRING,
   `bronTabelId` STRING,
@@ -41,7 +41,7 @@ TBLPROPERTIES (
 
 -- COMMAND ----------
 
-CREATE TABLE IF NOT EXISTS ${catalog}.dataquality.validatie (
+CREATE TABLE IF NOT EXISTS ${catalog}.data_quality.validatie (
   regelId STRING,
   aantalValideRecords BIGINT,
   aantalReferentieRecords BIGINT,
@@ -60,7 +60,7 @@ TBLPROPERTIES (
 
 -- COMMAND ----------
 
-CREATE TABLE IF NOT EXISTS ${catalog}.dataquality.afwijking (
+CREATE TABLE IF NOT EXISTS ${catalog}.data_quality.afwijking (
   regelId STRING,
   identifierVeldWaarde STRING,
   afwijkendeAttribuutWaarde STRING,
@@ -77,7 +77,7 @@ TBLPROPERTIES (
 
 -- COMMAND ----------
 
-CREATE TABLE IF NOT EXISTS ${catalog}.dataquality.brontabel (
+CREATE TABLE IF NOT EXISTS ${catalog}.data_quality.brontabel (
   bronTabelId STRING,
   uniekeSleutel STRING)
 USING delta

--- a/src/dq_suite/__init__.py
+++ b/src/dq_suite/__init__.py
@@ -1,8 +1,8 @@
 """DQ API."""
 
-from src.dq_suite.common import ValidationSettings
-from src.dq_suite.df_checker import run
-from src.dq_suite.input_helpers import schema_to_json_string
+from .common import ValidationSettings
+from .df_checker import run
+from .input_helpers import schema_to_json_string
 
 # Use __all__ to let developers know what is part of the public API.
 __all__ = ["schema_to_json_string", "run", "ValidationSettings"]

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -63,6 +63,11 @@ class DataQualityRulesDict:
 def get_full_table_name(
     catalog_name: str, table_name: str, schema_name: str = "data_quality"
 ) -> str:
+    if not (catalog_name.endswith("_dev") | catalog_name.endswith("_prd")):
+        raise ValueError(
+            f"Incorrect catalog name '{catalog_name}', should "
+            f"end with '_dev' or '_prd'."
+        )
     return f"{catalog_name}.{schema_name}.{table_name}"
 
 

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -4,8 +4,12 @@ from great_expectations.checkpoint import Checkpoint
 from great_expectations.validator.validator import Validator
 from pyspark.sql import DataFrame
 
-from src.dq_suite.common import (DataQualityRulesDict, Rule, RulesDict,
-                                 ValidationSettings)
+from src.dq_suite.common import (
+    DataQualityRulesDict,
+    Rule,
+    RulesDict,
+    ValidationSettings,
+)
 from src.dq_suite.input_helpers import get_data_quality_rules_dict
 from src.dq_suite.output_transformations import (
     write_non_validation_tables,
@@ -57,7 +61,7 @@ def create_and_run_checkpoint(
         batch_request=batch_request,
         expectation_suite_name=validation_settings_obj.expectation_suite_name,
         action_list=[
-            {
+            {  # TODO/check: do we really have to store the validation results?
                 "name": "store_validation_result",
                 "action": {"class_name": "StoreValidationResultAction"},
             },  # TODO: add more options via parameters, e.g. Slack output

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -5,7 +5,22 @@ from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col
 
 from src.dq_suite import ValidationSettings
-from src.dq_suite.common import DataQualityRulesDict
+from src.dq_suite.common import (
+    DataQualityRulesDict,
+    is_empty_dataframe,
+    write_to_unity_catalog,
+)
+from src.schemas.afwijking import SCHEMA as afwijking_schema
+from src.schemas.bronattribuut import SCHEMA as bronattribuut_schema
+from src.schemas.brontabel import SCHEMA as brontabel_schema
+from src.schemas.regel import SCHEMA as regel_schema
+from src.schemas.validatie import SCHEMA as validatie_schema
+
+
+def list_of_dicts_to_df(
+    list_of_dicts: List[dict], spark_session: SparkSession
+) -> DataFrame:
+    return spark_session.createDataFrame(Row(**x) for x in list_of_dicts)
 
 
 def extract_dq_validatie_data(

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -9,11 +9,11 @@ from src.dq_suite.common import (
     is_empty_dataframe,
     write_to_unity_catalog,
 )
-from src.schemas.afwijking import SCHEMA as afwijking_schema
-from src.schemas.bronattribuut import SCHEMA as bronattribuut_schema
-from src.schemas.brontabel import SCHEMA as brontabel_schema
-from src.schemas.regel import SCHEMA as regel_schema
-from src.schemas.validatie import SCHEMA as validatie_schema
+from src.schemas.afwijking import SCHEMA as AFWIJKING_SCHEMA
+from src.schemas.bronattribuut import SCHEMA as BRONATTRIBUUT_SCHEMA
+from src.schemas.brontabel import SCHEMA as BRONTABEL_SCHEMA
+from src.schemas.regel import SCHEMA as REGEL_SCHEMA
+from src.schemas.validatie import SCHEMA as VALIDATIE_SCHEMA
 
 
 def list_of_dicts_to_df(
@@ -68,7 +68,7 @@ def extract_dq_validatie_data(
             df=df_validatie,
             catalog_name=catalog_name,
             table_name="validatie",
-            schema=validatie_schema,
+            schema=VALIDATIE_SCHEMA,
         )
     else:
         # TODO: implement (raise error?)
@@ -147,7 +147,7 @@ def extract_dq_afwijking_data(
             df=df_afwijking,
             catalog_name=catalog_name,
             table_name="afwijking",
-            schema=afwijking_schema,
+            schema=AFWIJKING_SCHEMA,
         )
     else:
         # TODO: implement (raise error?)
@@ -182,7 +182,7 @@ def create_brontabel(
         df=df_brontabel,
         catalog_name=catalog_name,
         table_name="brontabel",
-        schema=brontabel_schema,
+        schema=BRONTABEL_SCHEMA,
     )
 
 
@@ -228,11 +228,11 @@ def create_bronattribute(
         df=df_bronattribuut,
         catalog_name=catalog_name,
         table_name="bronattribuut",
-        schema=bronattribuut_schema,
+        schema=BRONATTRIBUUT_SCHEMA,
     )
 
 
-def create_dqRegel(
+def create_dq_regel(
     dq_rules_dict: DataQualityRulesDict,
     catalog_name: str,
     spark_session: SparkSession,
@@ -257,7 +257,8 @@ def create_dqRegel(
                     attribute_name = parameter["column"]
                     extracted_data.append(
                         {
-                            "regelId": f"{bron_tabel}_{rule_name}_{attribute_name}",
+                            "regelId": f"{bron_tabel}_{rule_name}_"
+                            f"{attribute_name}",
                             "bronAttribuutId": f"{bron_tabel}_{attribute_name}",
                             "bronTabelId": bron_tabel,
                         }
@@ -270,7 +271,7 @@ def create_dqRegel(
         df=df_regel,
         catalog_name=catalog_name,
         table_name="regel",
-        schema=regel_schema,
+        schema=REGEL_SCHEMA,
     )
 
 
@@ -288,7 +289,7 @@ def write_non_validation_tables(
         catalog_name=validation_settings_obj.catalog_name,
         spark_session=validation_settings_obj.spark_session,
     )
-    create_dqRegel(
+    create_dq_regel(
         dq_rules_dict=dq_rules_dict,
         catalog_name=validation_settings_obj.catalog_name,
         spark_session=validation_settings_obj.spark_session,

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -43,6 +43,7 @@ def extract_dq_validatie_data(
             }
         )
     # Create a DataFrame
+    # TODO: create a PySpark dataframe directly, without use of pandas
     df_dq_validatie = pd.DataFrame(extracted_data)
     if not df_dq_validatie.empty:
         spark.createDataFrame(df_dq_validatie).write.mode("append").option(
@@ -118,6 +119,7 @@ def extract_dq_afwijking_data(
                     )
 
     # Create a DataFrame
+    # TODO: create a PySpark dataframe directly, without use of pandas
     df_dq_afwijking = pd.DataFrame(extracted_data)
     if not df_dq_afwijking.empty:
         spark.createDataFrame(df_dq_afwijking).write.mode("append").option(
@@ -149,6 +151,7 @@ def create_brontabel(
             {"bronTabelId": name, "uniekeSleutel": unique_identifier}
         )
 
+    # TODO: create a PySpark dataframe directly, without use of pandas
     df_brontable = pd.DataFrame(extracted_data)
     spark_session.createDataFrame(df_brontable).write.mode("append").option(
         "overwriteSchema", "true"
@@ -190,6 +193,7 @@ def create_bronattribute(
                             }
                         )
 
+    # TODO: create a PySpark dataframe directly, without use of pandas
     df_bronattribuut = pd.DataFrame(extracted_data)
     spark_session.createDataFrame(df_bronattribuut).write.mode("append").option(
         "overwriteSchema", "true"
@@ -227,6 +231,7 @@ def create_dqRegel(
                         }
                     )
 
+    # TODO: create a PySpark dataframe directly, without use of pandas
     df_dqRegel = pd.DataFrame(extracted_data)
     spark_session.createDataFrame(df_dqRegel).write.mode("append").option(
         "overwriteSchema", "true"

--- a/src/schemas/afwijking.py
+++ b/src/schemas/afwijking.py
@@ -1,0 +1,9 @@
+from pyspark.sql.types import StructType
+
+SCHEMA = (
+    StructType()
+    .add("regelId", "string")
+    .add("identifierVeldWaarde", "string")
+    .add("afwijkendeAttribuutWaarde", "string")
+    .add("dqDatum", "timestamp")
+)

--- a/src/schemas/bronattribuut.py
+++ b/src/schemas/bronattribuut.py
@@ -1,0 +1,8 @@
+from pyspark.sql.types import StructType
+
+SCHEMA = (
+    StructType()
+    .add("bronAttribuutId", "string")
+    .add("attribuutNaam", "string")
+    .add("bronTabelId", "string")
+)

--- a/src/schemas/brontabel.py
+++ b/src/schemas/brontabel.py
@@ -1,0 +1,5 @@
+from pyspark.sql.types import StructType
+
+SCHEMA = (
+    StructType().add("bronTabelId", "string").add("uniekeSleutel", "string")
+)

--- a/src/schemas/regel.py
+++ b/src/schemas/regel.py
@@ -1,0 +1,8 @@
+from pyspark.sql.types import StructType
+
+SCHEMA = (
+    StructType()
+    .add("bronTabelId", "string")
+    .add("bronAttribuutId", "string")
+    .add("regelId", "string")
+)

--- a/src/schemas/validatie.py
+++ b/src/schemas/validatie.py
@@ -1,0 +1,10 @@
+from pyspark.sql.types import StructType
+
+SCHEMA = (
+    StructType()
+    .add("regelId", "string")
+    .add("aantalValideRecords", "long")
+    .add("aantalReferentieRecords", "long")
+    .add("dqDatum", "timestamp")
+    .add("dqResultaat", "string")
+)


### PR DESCRIPTION
Attempt at writing a generic function for writing PySpark dataframes to unity catalog. Main changes include: 

- Modified and applied `write_to_unity_catalog` from `common.py`
- Added `is_empty_dataframe`, `enforce_column_order` and `enforce_schema` to `common.py`
- Removed use of Pandas, added `list_of_dicts_to_df` function instead
- Added schemas of various `data_quality` tables