### PR TITLE
Issue 28: Add notification actions via GX checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ dq_suite.run(json_path=dq_rule_json_path, df=df, validation_settings_obj=validat
 ```
 Looping over multiple data frames may require a redefinition of the `json_path` and `validation_settings` variables. 
 
+See the documentation of `ValidationSettings` for what other parameters can be passed upon intialisation (e.g. Slack 
+or MS Teams webhooks for notifications, location for storing GX, etc). 
+
 
 # Create data quality schema and tables (in respective catalog of data team)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dq-suite-amsterdam"
-version = "0.7.4"
+version = "0.7.5"
 authors = [
   { name="Arthur Kordes", email="a.kordes@amsterdam.nl" },
   { name="Aysegul Cayir Aydar", email="a.cayiraydar@amsterdam.nl" },

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -172,6 +172,12 @@ class ValidationSettings:
             raise TypeError("'table_name' should be of type str")
         if not isinstance(self.check_name, str):
             raise TypeError("'check_name' should be of type str")
+        if not isinstance(self.data_context_root_dir, str):
+            raise TypeError("'data_context_root_dir' should be of type str")
+        if self.notify_on not in ["all", "success", "failure"]:
+            raise ValueError(
+                "'notify_on' should be equal to 'all', 'success' or 'failure'"
+            )
 
     def initialise_or_update_attributes(self):  # pragma: no cover - complex
         # function

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -149,7 +149,7 @@ def get_data_context(
 @dataclass()
 class ValidationSettings:
     """
-    spark_session: Spark session object
+    spark_session: SparkSession object
     catalog_name: name of unity catalog
     table_name: name of table in unity catalog
     check_name: name of data quality check

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -148,6 +148,26 @@ def get_data_context(
 
 @dataclass()
 class ValidationSettings:
+    """
+    spark_session: Spark session object
+    catalog_name: name of unity catalog
+    table_name: name of table in unity catalog
+    check_name: name of data quality check
+    data_context_root_dir: path to write GX data
+    context - default "/dbfs/great_expectations/"
+    data_context: a data context object
+    expectation_suite_name: name of the GX expectation suite
+    checkpoint_name: name of the GX checkpoint
+    run_name: name of the data quality run
+    send_slack_notification: indicator to use GX's built-in Slack
+    notification action
+    slack_webhook: webhook, recommended to store in key vault
+    send_ms_teams_notification: indicator to use GX's built-in Microsoft
+    Teams notification action
+    ms_teams_webhook: webhook, recommended to store in key vault
+    notify_on: when to send notifications, can be equal to "all",
+    "success" or "failure"
+    """
     spark_session: SparkSession
     catalog_name: str
     table_name: str

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -157,6 +157,11 @@ class ValidationSettings:
     expectation_suite_name: str | None = None
     checkpoint_name: str | None = None
     run_name: str | None = None
+    send_slack_notification: bool = False
+    slack_webhook: str | None = None
+    send_ms_teams_notification: bool = False
+    ms_teams_webhook: str | None = None
+    notify_on: Literal["all", "success", "failure"] = "failure"
 
     def __post_init__(self):
         if not isinstance(self.spark_session, SparkSession):

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -78,7 +78,8 @@ def create_action_list(
                 "name": "send_ms_teams_notification",
                 "action": {
                     "class_name": "MicrosoftTeamsNotificationAction",
-                    "slack_webhook": validation_settings_obj.ms_teams_webhook,
+                    "microsoft_teams_webhook":
+                        validation_settings_obj.ms_teams_webhook,
                     "notify_on": validation_settings_obj.notify_on,
                 },
             }

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -68,12 +68,10 @@ def create_action_list(
                     "class_name": "SlackNotificationAction",
                     "slack_webhook": validation_settings_obj.slack_webhook,
                     "notify_on": validation_settings_obj.notify_on,
-                    "renderer":
-                        {
-                            "module_name":
-                                "great_expectations.render.renderer.slack_renderer",
-                            "class_name": "SlackRenderer",
-                        },
+                    "renderer": {
+                        "module_name": "great_expectations.render.renderer.slack_renderer",
+                        "class_name": "SlackRenderer",
+                    },
                 },
             }
         )
@@ -86,15 +84,12 @@ def create_action_list(
                 "name": "send_ms_teams_notification",
                 "action": {
                     "class_name": "MicrosoftTeamsNotificationAction",
-                    "microsoft_teams_webhook":
-                        validation_settings_obj.ms_teams_webhook,
+                    "microsoft_teams_webhook": validation_settings_obj.ms_teams_webhook,
                     "notify_on": validation_settings_obj.notify_on,
-                    "renderer":
-                        {
-                            "module_name":
-                                "great_expectations.render.renderer.microsoft_teams_renderer",
-                            "class_name": "MicrosoftTeamsRenderer",
-                        },
+                    "renderer": {
+                        "module_name": "great_expectations.render.renderer.microsoft_teams_renderer",
+                        "class_name": "MicrosoftTeamsRenderer",
+                    },
                 },
             }
         )

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -49,12 +49,14 @@ def get_batch_request_and_validator(
 def create_action_list(
     validation_settings_obj: ValidationSettings,
 ) -> List[dict[str, Any]]:
-    action_list = [
-        {  # TODO/check: do we really have to store the validation results?
-            "name": "store_validation_result",
-            "action": {"class_name": "StoreValidationResultAction"},
-        },
-    ]
+    action_list = list()
+
+    # action_list.append(
+    #     {  # TODO/check: do we really have to store the validation results?
+    #         "name": "store_validation_result",
+    #         "action": {"class_name": "StoreValidationResultAction"},
+    #     }
+    # )
 
     if validation_settings_obj.send_slack_notification & (
         validation_settings_obj.slack_webhook is not None

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -87,6 +87,12 @@ def create_action_list(
                     "microsoft_teams_webhook":
                         validation_settings_obj.ms_teams_webhook,
                     "notify_on": validation_settings_obj.notify_on,
+                    "renderer":
+                        {
+                            "module_name":
+                                "great_expectations.render.renderer.microsoft_teams_renderer",
+                            "class_name": "MicrosoftTeamsRenderer",
+                        },
                 },
             }
         )

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -66,6 +66,12 @@ def create_action_list(
                     "class_name": "SlackNotificationAction",
                     "slack_webhook": validation_settings_obj.slack_webhook,
                     "notify_on": validation_settings_obj.notify_on,
+                    "renderer":
+                        {
+                            "module_name":
+                                "great_expectations.render.renderer.slack_renderer",
+                            "class_name": "SlackRenderer",
+                        },
                 },
             }
         )


### PR DESCRIPTION
This PR adds two options for sending notifications directly upon finishing a validation: Slack notifications and MS Teams notifications. These can be added via the `ValidationSettings` initialisation, and (following GX) notifications can be sent upon success only, failure only, or in both cases. 