### PR TITLE
Upgrade GX to version 1.0

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Using a Shared Compute Cluster will result in an error, as it does not have the 
 ([click](https://docs.databricks.com/en/release-notes/runtime/13.3lts.html#system-environment)). 
 Older versions of DBR will result in errors upon install of the `dq-suite-amsterdam` library.
 
+- At time of writing (late Aug 2024), Great Expectations v1.0.0 has just been released, and is not (yet) compatible with Python 3.12. Hence, make sure you are using the correct version of Python as interpreter for your project. 
 
 # Contributing to this library
 See the separate [developers' readme](src/Readme-dev.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ description = "Wrapper for Great Expectations to fit the requirements of the Gem
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "great_expectations==1.0.1",
+  "great_expectations==1.0.3",
   "pandas==2.1.4",
   "pyspark==3.3.2",
   "pyhumps==3.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ description = "Wrapper for Great Expectations to fit the requirements of the Gem
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "great_expectations==1.0.0",
+  "great_expectations==1.0.1",
   "pandas==2.1.4",
   "pyspark==3.3.2",
   "pyhumps==3.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "great_expectations==1.0.0",
   "pandas==2.1.4",
   "pyspark==3.3.2",
+  "pyhumps==3.8.0",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "pandas==2.1.4",
   "pyspark==3.5.2",
   "pyhumps==3.8.0",
+  "pyyaml==6.0.2",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dq-suite-amsterdam"
-version = "0.7.6"
+version = "0.7.7"
 authors = [
   { name="Arthur Kordes", email="a.kordes@amsterdam.nl" },
   { name="Aysegul Cayir Aydar", email="a.cayiraydar@amsterdam.nl" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ description = "Wrapper for Great Expectations to fit the requirements of the Gem
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "great_expectations==0.18.19",
-  "pandas==2.2.2",
+  "great_expectations==1.0.0",
+  "pandas==2.1.4",
   "pyspark==3.3.2",
 ]
 

--- a/src/dq_suite/__init__.py
+++ b/src/dq_suite/__init__.py
@@ -1,8 +1,8 @@
-"""DQ API."""
-
-from .common import ValidationSettings
-from .df_checker import run
-from .input_helpers import schema_to_json_string
-
-# Use __all__ to let developers know what is part of the public API.
-__all__ = ["schema_to_json_string", "run", "ValidationSettings"]
+# """DQ API."""
+#
+# from .common import ValidationSettings
+# from .df_checker import run
+# from .input_helpers import schema_to_json_string
+#
+# # Use __all__ to let developers know what is part of the public API.
+# __all__ = ["schema_to_json_string", "run", "ValidationSettings"]

--- a/src/dq_suite/__init__.py
+++ b/src/dq_suite/__init__.py
@@ -1,8 +1,8 @@
-# """DQ API."""
-#
-# from .common import ValidationSettings
-# from .df_checker import run
-# from .input_helpers import schema_to_json_string
-#
-# # Use __all__ to let developers know what is part of the public API.
-# __all__ = ["schema_to_json_string", "run", "ValidationSettings"]
+"""DQ API."""
+
+from .common import ValidationSettings
+from .df_checker import run
+from .input_helpers import schema_to_json_string
+
+# Use __all__ to let developers know what is part of the public API.
+__all__ = ["schema_to_json_string", "run", "ValidationSettings"]

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -8,9 +8,9 @@ from great_expectations.data_context import (
     EphemeralDataContext,
 )
 from great_expectations.data_context.types.base import (
-        DataContextConfig,
-        InMemoryStoreBackendDefaults,
-    )
+    DataContextConfig,
+    InMemoryStoreBackendDefaults,
+)
 from great_expectations.exceptions import DataContextError
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -1,8 +1,16 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal
+import yaml
 
 from great_expectations import ExpectationSuite, get_context
-from great_expectations.data_context import AbstractDataContext
+from great_expectations.data_context import (
+    AbstractDataContext,
+    EphemeralDataContext,
+)
+from great_expectations.data_context.types.base import (
+        DataContextConfig,
+        InMemoryStoreBackendDefaults,
+    )
 from great_expectations.exceptions import DataContextError
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col
@@ -207,10 +215,13 @@ def merge_df_with_unity_table(
         .execute()
 
 
-def get_data_context(
-    data_context_root_dir: str = "/dbfs/great_expectations/",
-) -> AbstractDataContext:  # pragma: no cover - part of GX
-    return get_context(context_root_dir=data_context_root_dir)
+def get_data_context() -> AbstractDataContext:  # pragma: no cover - part of GX
+    return get_context(
+        project_config=DataContextConfig(
+            store_backend_defaults=InMemoryStoreBackendDefaults(),
+            analytics_enabled=False
+        )
+    )
 
 
 @dataclass()
@@ -285,9 +296,7 @@ class ValidationSettings:
             )
 
     def _set_data_context(self):  # pragma: no cover - uses part of GX
-        self.data_context = get_data_context(
-            data_context_root_dir=self.data_context_root_dir
-        )
+        self.data_context = get_data_context()
 
     def _set_expectation_suite_name(self):
         self.expectation_suite_name = f"{self.check_name}_expectation_suite"

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal
 
-from great_expectations import ExpectationSuite, get_context
+from great_expectations import get_context, ExpectationSuite
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.exceptions import DataContextError
 from pyspark.sql import DataFrame, SparkSession
@@ -212,10 +212,9 @@ class ValidationSettings:
 
         # Finally, add/retrieve the suite to/from the data context
         try:
-            self.get_data_context().suites.get(
-                name=self.expectation_suite_name)
+            self.data_context.suites.get(name=self.expectation_suite_name)
         except DataContextError:
-            self.get_data_context().suites.add(
+            self.data_context.suites.add(
                 suite=ExpectationSuite(name=self.expectation_suite_name)
             )
 
@@ -232,6 +231,3 @@ class ValidationSettings:
 
     def _set_run_name(self):
         self.run_name = f"%Y%m%d-%H%M%S-{self.check_name}"
-
-    def get_data_context(self):
-        return self.data_context

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Literal
 
 from great_expectations import get_context, ExpectationSuite
 from great_expectations.data_context import AbstractDataContext
+from great_expectations.exceptions import DataContextError
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col
 from pyspark.sql.types import StructType
@@ -209,10 +210,13 @@ class ValidationSettings:
         self._set_checkpoint_name()
         self._set_run_name()
 
-        # Finally, add the (new) suite to the data context
-        self.data_context.suites.add(
-            suite=ExpectationSuite(name=self.expectation_suite_name)
-        )
+        # Finally, add/retrieve the suite to/from the data context
+        try:
+            self.data_context.suites.get(name=self.expectation_suite_name)
+        except DataContextError:
+            self.data_context.suites.add(
+                suite=ExpectationSuite(name=self.expectation_suite_name)
+            )
 
     def _set_data_context(self):  # pragma: no cover - uses part of GX
         self.data_context = get_data_context(

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal
 
-from great_expectations import get_context, ExpectationSuite
+from great_expectations import ExpectationSuite, get_context
 from great_expectations.data_context import AbstractDataContext
 from great_expectations.exceptions import DataContextError
 from pyspark.sql import DataFrame, SparkSession

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal
 
-from great_expectations import get_context
+from great_expectations import get_context, ExpectationSuite
 from great_expectations.data_context import AbstractDataContext
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col
@@ -209,9 +209,9 @@ class ValidationSettings:
         self._set_checkpoint_name()
         self._set_run_name()
 
-        # Finally, apply the (new) suite name to the data context
+        # Finally, add the (new) suite to the data context
         self.data_context.suites.add(
-            expectation_suite_name=self.expectation_suite_name
+            suite=ExpectationSuite(name=self.expectation_suite_name)
         )
 
     def _set_data_context(self):  # pragma: no cover - uses part of GX

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -205,7 +205,7 @@ class ValidationSettings:
         # function
         self._set_data_context()
 
-        # TODO/check: do we want to allow for custom names?
+        # TODO/check: do we want to allow for custom names via parameters?
         self._set_expectation_suite_name()
         self._set_checkpoint_name()
         self._set_run_name()

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -168,6 +168,7 @@ class ValidationSettings:
     notify_on: when to send notifications, can be equal to "all",
     "success" or "failure"
     """
+
     spark_session: SparkSession
     catalog_name: str
     table_name: str
@@ -209,7 +210,7 @@ class ValidationSettings:
         self._set_run_name()
 
         # Finally, apply the (new) suite name to the data context
-        self.data_context.add_or_update_expectation_suite(
+        self.data_context.suites.add(
             expectation_suite_name=self.expectation_suite_name
         )
 

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -212,9 +212,10 @@ class ValidationSettings:
 
         # Finally, add/retrieve the suite to/from the data context
         try:
-            self.data_context.suites.get(name=self.expectation_suite_name)
+            self.get_data_context().suites.get(
+                name=self.expectation_suite_name)
         except DataContextError:
-            self.data_context.suites.add(
+            self.get_data_context().suites.add(
                 suite=ExpectationSuite(name=self.expectation_suite_name)
             )
 
@@ -231,3 +232,6 @@ class ValidationSettings:
 
     def _set_run_name(self):
         self.run_name = f"%Y%m%d-%H%M%S-{self.check_name}"
+
+    def get_data_context(self):
+        return self.data_context

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -123,7 +123,7 @@ def get_or_add_checkpoint(
             validation_settings_obj=validation_settings_obj
         )
         checkpoint = Checkpoint(
-            name=validation_settings_obj.checkpoint_name,
+            name=str(validation_settings_obj.checkpoint_name),
             validation_definitions=validation_definitions_list,
             action_list=action_list,
         )  # Note: a checkpoint combines validations with actions

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -3,7 +3,7 @@ from typing import Any, List
 import great_expectations
 import humps
 from great_expectations import ValidationDefinition
-from great_expectations.checkpoint import Checkpoint
+from great_expectations import Checkpoint
 from great_expectations.checkpoint.actions import CheckpointAction
 from great_expectations.checkpoint.checkpoint import CheckpointResult
 from great_expectations.exceptions import DataContextError

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -66,7 +66,8 @@ def get_or_add_validation_definition(
         validation_definition = ValidationDefinition(
             name=validation_definition_name,
             data=batch_definition,
-            suite=validation_settings_obj.expectation_suite_name,
+            suite=validation_settings_obj.data_context.suites.get(
+                validation_settings_obj.expectation_suite_name),
         )  # Note: a validation definition combines data with a suite of
         # expectations
         validation_definition = (

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -183,7 +183,7 @@ def validate(
     df: DataFrame,
     rules_dict: RulesDict,
     validation_settings_obj: ValidationSettings,
-) -> Any:
+) -> CheckpointResult:
     """
     [explanation goes here]
 
@@ -195,21 +195,22 @@ def validate(
     # Make sure all attributes are aligned before validating
     validation_settings_obj.initialise_or_update_attributes()
 
-    batch, validator = get_batch_request_and_validator(
-        df=df,
-        validation_settings_obj=validation_settings_obj,
-    )
-
     create_and_configure_expectations(
-        validation_rules_list=rules_dict["rules"], validator=validator
-    )
-
-    checkpoint_output = create_and_run_checkpoint(
+        validation_rules_list=rules_dict["rules"],
         validation_settings_obj=validation_settings_obj,
-        batch=batch,
     )
 
-    return checkpoint_output
+    validation_definition = get_or_add_validation_definition(
+        validation_settings_obj=validation_settings_obj,
+    )
+
+    checkpoint = get_or_add_checkpoint(
+        validation_settings_obj=validation_settings_obj,
+        validation_definitions_list=[validation_definition],
+    )
+
+    batch_params = {"dataframe": df}
+    return checkpoint.run(batch_parameters=batch_params)
 
 
 def run(

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -125,7 +125,7 @@ def get_or_add_checkpoint(
         checkpoint = Checkpoint(
             name=validation_settings_obj.checkpoint_name,
             validation_definitions=[validation_definition],
-            action_list=action_list,
+            actions=action_list,
         )  # Note: a checkpoint combines validations with actions
 
         # Add checkpoint to data context for future use

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -213,7 +213,8 @@ def validate(
     validation_definition = get_or_add_validation_definition(
         validation_settings_obj=validation_settings_obj,
     )
-
+    print("***Starting validation definition run***")
+    print(validation_definition.run())
     checkpoint = get_or_add_checkpoint(
         validation_settings_obj=validation_settings_obj,
         validation_definitions_list=[validation_definition],

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -30,7 +30,7 @@ def get_or_add_validation_definition(
     validation_settings_obj: ValidationSettings,
 ) -> ValidationDefinition:
     dataframe_datasource = (
-        validation_settings_obj.data_context.data_sources.add_or_update_spark(
+        validation_settings_obj.get_data_context().data_sources.add_or_update_spark(
             name=f"spark_datasource_" f"{validation_settings_obj.check_name}"
         )
     )
@@ -48,7 +48,7 @@ def get_or_add_validation_definition(
     # batch_request = df_asset.build_batch_request()
     # batch = batch_definition.get_batch(batch_parameters=batch_params)
 
-    # validator = validation_settings_obj.data_context.get_validator(
+    # validator = validation_settings_obj.get_data_context().get_validator(
     #     batch=batch,
     #     expectation_suite_name=validation_settings_obj.expectation_suite_name,
     # )
@@ -58,7 +58,7 @@ def get_or_add_validation_definition(
     )
     try:
         validation_definition = (
-            validation_settings_obj.data_context.validation_definitions.get(
+            validation_settings_obj.get_data_context().validation_definitions.get(
                 name=validation_definition_name
             )
         )
@@ -70,7 +70,7 @@ def get_or_add_validation_definition(
         )  # Note: a validation definition combines data with a suite of
         # expectations
         validation_definition = (
-            validation_settings_obj.data_context.validation_definitions.add(
+            validation_settings_obj.get_data_context().validation_definitions.add(
                 validation=validation_definition
             )
         )
@@ -134,7 +134,7 @@ def get_or_add_checkpoint(
     validation_definitions_list: List[ValidationDefinition],
 ) -> Checkpoint:
     try:
-        checkpoint = validation_settings_obj.data_context.checkpoints.get(
+        checkpoint = validation_settings_obj.get_data_context().checkpoints.get(
             name=validation_settings_obj.checkpoint_name
         )
     except DataContextError:
@@ -149,7 +149,7 @@ def get_or_add_checkpoint(
 
         # Add checkpoint to data context for future use
         (
-            validation_settings_obj.data_context.checkpoints.add(
+            validation_settings_obj.get_data_context().checkpoints.add(
                 checkpoint=checkpoint
             )
         )
@@ -161,7 +161,7 @@ def create_and_configure_expectations(
     validation_settings_obj: ValidationSettings,
 ) -> None:
     # The suite should exist by now
-    suite = validation_settings_obj.data_context.suites.get(
+    suite = validation_settings_obj.get_data_context().suites.get(
         name=validation_settings_obj.expectation_suite_name
     )
 

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -43,17 +43,6 @@ def get_or_add_validation_definition(
         name=f"{validation_settings_obj.check_name}_batch_definition"
     )
 
-    # df_asset = dataframe_datasource.add_dataframe_asset(
-    #     name=validation_settings_obj.check_name, dataframe=df
-    # )
-    # batch_request = df_asset.build_batch_request()
-    # batch = batch_definition.get_batch(batch_parameters=batch_params)
-
-    # validator = validation_settings_obj.data_context.get_validator(
-    #     batch=batch,
-    #     expectation_suite_name=validation_settings_obj.expectation_suite_name,
-    # )
-
     validation_definition_name = (
         f"{validation_settings_obj.check_name}" f"_validation_definition"
     )
@@ -214,7 +203,7 @@ def validate(
         validation_settings_obj=validation_settings_obj,
     )
     print("***Starting validation definition run***")
-    print(validation_definition.run())
+    print(validation_definition.run(batch_parameters={"dataframe": df}))
     checkpoint = get_or_add_checkpoint(
         validation_settings_obj=validation_settings_obj,
         validation_definitions_list=[validation_definition],

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -74,47 +74,37 @@ def create_action_list(
 ) -> List[CheckpointAction]:
     action_list = list()
 
-    # action_list.append(
-    #     {  # TODO/check: do we really have to store the validation results?
-    #         "name": "store_validation_result",
-    #         "action": {"class_name": "StoreValidationResultAction"},
-    #     }
-    # )
+    # action_list.append(great_expectations.checkpoint.UpdateDataDocsAction(
+    #     name="update_data_docs"))
 
     if validation_settings_obj.send_slack_notification & (
         validation_settings_obj.slack_webhook is not None
     ):
         action_list.append(
-            {
-                "name": "send_slack_notification",
-                "action": {
-                    "class_name": "SlackNotificationAction",
-                    "slack_webhook": validation_settings_obj.slack_webhook,
-                    "notify_on": validation_settings_obj.notify_on,
-                    "renderer": {
-                        "module_name": "great_expectations.render.renderer.slack_renderer",
-                        "class_name": "SlackRenderer",
-                    },
+            great_expectations.checkpoint.SlackNotificationAction(
+                name="send_slack_notification",
+                slack_webhook=validation_settings_obj.slack_webhook,
+                notify_on=validation_settings_obj.notify_on,
+                renderer={
+                    "module_name": "great_expectations.render.renderer.slack_renderer",
+                    "class_name": "SlackRenderer",
                 },
-            }
+            )
         )
 
     if validation_settings_obj.send_ms_teams_notification & (
         validation_settings_obj.ms_teams_webhook is not None
     ):
         action_list.append(
-            {
-                "name": "send_ms_teams_notification",
-                "action": {
-                    "class_name": "MicrosoftTeamsNotificationAction",
-                    "microsoft_teams_webhook": validation_settings_obj.ms_teams_webhook,
-                    "notify_on": validation_settings_obj.notify_on,
-                    "renderer": {
-                        "module_name": "great_expectations.render.renderer.microsoft_teams_renderer",
-                        "class_name": "MicrosoftTeamsRenderer",
-                    },
+            great_expectations.checkpoint.MicrosoftTeamsNotificationAction(
+                name="send_ms_teams_notification",
+                microsoft_teams_webhook=validation_settings_obj.ms_teams_webhook,
+                notify_on=validation_settings_obj.notify_on,
+                renderer={
+                    "module_name": "great_expectations.render.renderer.microsoft_teams_renderer",
+                    "class_name": "MicrosoftTeamsRenderer",
                 },
-            }
+            )
         )
 
     return action_list
@@ -165,11 +155,13 @@ def create_and_configure_expectations(
             great_expectations.expectations.core,
             humps.pascalize(gx_expectation_name),
         )
-        # TODO: drop pascalization, and require this as input check when
-        #  ingesting JSON? Could be done via humps.is_pascalcase()
+        # Issue 50
+        # TODO: drop pascalization, and require this as input check
+        #  when ingesting JSON? Could be done via humps.is_pascalcase()
 
         for validation_parameter_dict in validation_rule["parameters"]:
             kwargs = {}
+            # Issue 51
             # TODO/check: is this loop really necessary? Intuitively, I added
             #  the same expectation for each column - I didn't consider using
             #  the same expectation with different parameters

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -30,7 +30,7 @@ def get_or_add_validation_definition(
     validation_settings_obj: ValidationSettings,
 ) -> ValidationDefinition:
     dataframe_datasource = (
-        validation_settings_obj.get_data_context().data_sources.add_or_update_spark(
+        validation_settings_obj.data_context.data_sources.add_or_update_spark(
             name=f"spark_datasource_" f"{validation_settings_obj.check_name}"
         )
     )
@@ -48,7 +48,7 @@ def get_or_add_validation_definition(
     # batch_request = df_asset.build_batch_request()
     # batch = batch_definition.get_batch(batch_parameters=batch_params)
 
-    # validator = validation_settings_obj.get_data_context().get_validator(
+    # validator = validation_settings_obj.data_context.get_validator(
     #     batch=batch,
     #     expectation_suite_name=validation_settings_obj.expectation_suite_name,
     # )
@@ -58,7 +58,7 @@ def get_or_add_validation_definition(
     )
     try:
         validation_definition = (
-            validation_settings_obj.get_data_context().validation_definitions.get(
+            validation_settings_obj.data_context.validation_definitions.get(
                 name=validation_definition_name
             )
         )
@@ -70,7 +70,7 @@ def get_or_add_validation_definition(
         )  # Note: a validation definition combines data with a suite of
         # expectations
         validation_definition = (
-            validation_settings_obj.get_data_context().validation_definitions.add(
+            validation_settings_obj.data_context.validation_definitions.add(
                 validation=validation_definition
             )
         )
@@ -134,7 +134,7 @@ def get_or_add_checkpoint(
     validation_definitions_list: List[ValidationDefinition],
 ) -> Checkpoint:
     try:
-        checkpoint = validation_settings_obj.get_data_context().checkpoints.get(
+        checkpoint = validation_settings_obj.data_context.checkpoints.get(
             name=validation_settings_obj.checkpoint_name
         )
     except DataContextError:
@@ -149,7 +149,7 @@ def get_or_add_checkpoint(
 
         # Add checkpoint to data context for future use
         (
-            validation_settings_obj.get_data_context().checkpoints.add(
+            validation_settings_obj.data_context.checkpoints.add(
                 checkpoint=checkpoint
             )
         )
@@ -161,7 +161,7 @@ def create_and_configure_expectations(
     validation_settings_obj: ValidationSettings,
 ) -> None:
     # The suite should exist by now
-    suite = validation_settings_obj.get_data_context().suites.get(
+    suite = validation_settings_obj.data_context.suites.get(
         name=validation_settings_obj.expectation_suite_name
     )
 

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -234,11 +234,12 @@ def run(
         return
 
     # 2) perform the validation on the dataframe
-    validation_output = validate(
+    checkpoint_result = validate(
         df=df,
         rules_dict=rules_dict,
         validation_settings_obj=validation_settings_obj,
     )
+    validation_output = checkpoint_result["run_results"]
 
     # 3) write results to unity catalog
     write_non_validation_tables(

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -1,6 +1,7 @@
 from typing import Any, List, Tuple
 
 from great_expectations.checkpoint import Checkpoint
+from great_expectations.exceptions import DataContextError
 from great_expectations.validator.validator import Validator
 from pyspark.sql import DataFrame
 
@@ -144,7 +145,10 @@ def create_and_configure_expectations(
                 kwargs[par_name] = par_value
             gx_expectation(**kwargs)
 
-    validator.save_expectation_suite(discard_failed_expectations=False)
+    try:
+        validator.save_expectation_suite(discard_failed_expectations=False)
+    except DataContextError:
+        return
 
 
 def validate(

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -27,7 +27,7 @@ def get_batch_request_and_validator(
     validation_settings_obj: ValidationSettings,
 ) -> Tuple[Any, Validator]:
     dataframe_datasource = (
-        validation_settings_obj.data_context.sources.add_or_update_spark(
+        validation_settings_obj.data_context.data_sources.add_or_update_spark(
             name="my_spark_in_memory_datasource_"
             + validation_settings_obj.check_name
         )
@@ -112,8 +112,10 @@ def create_and_run_checkpoint(
         action_list=action_list,
     )
 
-    validation_settings_obj.data_context.add_or_update_checkpoint(
-        checkpoint=checkpoint
+    (
+        validation_settings_obj.data_context.checkpoints.add(
+            checkpoint=checkpoint
+        )
     )
     checkpoint_result = checkpoint.run()
     return checkpoint_result["run_results"]

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Tuple
+from typing import Any, List
 
 import great_expectations
 import humps
@@ -6,7 +6,6 @@ from great_expectations import ValidationDefinition
 from great_expectations.checkpoint import Checkpoint
 from great_expectations.checkpoint.checkpoint import CheckpointResult
 from great_expectations.exceptions import DataContextError
-from great_expectations.validator.validator import Validator
 from pyspark.sql import DataFrame
 
 from .common import DataQualityRulesDict, Rule, RulesDict, ValidationSettings
@@ -32,13 +31,13 @@ def get_or_add_validation_definition(
 ) -> ValidationDefinition:
     dataframe_datasource = (
         validation_settings_obj.data_context.data_sources.add_or_update_spark(
-            name=f"spark_datasource_"
-                 f"{validation_settings_obj.check_name}"
+            name=f"spark_datasource_" f"{validation_settings_obj.check_name}"
         )
     )
 
     df_asset = dataframe_datasource.add_dataframe_asset(
-        name=validation_settings_obj.check_name)
+        name=validation_settings_obj.check_name
+    )
     batch_definition = df_asset.add_batch_definition_whole_dataframe(
         name=f"{validation_settings_obj.check_name}_batch_definition"
     )
@@ -54,12 +53,15 @@ def get_or_add_validation_definition(
     #     expectation_suite_name=validation_settings_obj.expectation_suite_name,
     # )
 
-    validation_definition_name = (f"{validation_settings_obj.check_name}"
-                                  f"_validation_definition")
+    validation_definition_name = (
+        f"{validation_settings_obj.check_name}" f"_validation_definition"
+    )
     try:
         validation_definition = (
             validation_settings_obj.data_context.validation_definitions.get(
-                name=validation_definition_name))
+                name=validation_definition_name
+            )
+        )
     except DataContextError:
         validation_definition = ValidationDefinition(
             name=validation_definition_name,
@@ -69,7 +71,9 @@ def get_or_add_validation_definition(
         # expectations
         validation_definition = (
             validation_settings_obj.data_context.validation_definitions.add(
-                validation=validation_definition))
+                validation=validation_definition
+            )
+        )
 
     return validation_definition
 
@@ -127,11 +131,12 @@ def create_action_list(
 
 def get_or_add_checkpoint(
     validation_settings_obj: ValidationSettings,
-        validation_definitions_list: List[ValidationDefinition],
+    validation_definitions_list: List[ValidationDefinition],
 ) -> Checkpoint:
     try:
         checkpoint = validation_settings_obj.data_context.checkpoints.get(
-            name=validation_settings_obj.checkpoint_name)
+            name=validation_settings_obj.checkpoint_name
+        )
     except DataContextError:
         action_list = create_action_list(
             validation_settings_obj=validation_settings_obj
@@ -157,15 +162,18 @@ def create_and_configure_expectations(
 ) -> None:
     # The suite should exist by now
     suite = validation_settings_obj.data_context.suites.get(
-        name=validation_settings_obj.expectation_suite_name)
+        name=validation_settings_obj.expectation_suite_name
+    )
 
     for validation_rule in validation_rules_list:
         # Get the name of expectation as defined by GX
         gx_expectation_name = validation_rule["rule_name"]
 
         # Get the actual expectation as defined by GX
-        gx_expectation = getattr(great_expectations.expectations.core,
-                                 humps.pascalize(gx_expectation_name))
+        gx_expectation = getattr(
+            great_expectations.expectations.core,
+            humps.pascalize(gx_expectation_name),
+        )
         # TODO: drop pascalization, and require this as input check when
         #  ingesting JSON? Could be done via humps.is_pascalcase()
 

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -231,7 +231,7 @@ def run(
         rules_dict=rules_dict,
         validation_settings_obj=validation_settings_obj,
     )
-    validation_output = checkpoint_result["run_results"]
+    validation_output = checkpoint_result.describe_dict()
 
     # 3) write results to unity catalog
     write_non_validation_tables(

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -1,9 +1,8 @@
-from typing import Any, List
+from typing import List
 
 import great_expectations
 import humps
-from great_expectations import ValidationDefinition
-from great_expectations import Checkpoint
+from great_expectations import Checkpoint, ValidationDefinition
 from great_expectations.checkpoint.actions import CheckpointAction
 from great_expectations.checkpoint.checkpoint import CheckpointResult
 from great_expectations.exceptions import DataContextError
@@ -57,7 +56,8 @@ def get_or_add_validation_definition(
             name=validation_definition_name,
             data=batch_definition,
             suite=validation_settings_obj.data_context.suites.get(
-                validation_settings_obj.expectation_suite_name),
+                validation_settings_obj.expectation_suite_name
+            ),
         )  # Note: a validation definition combines data with a suite of
         # expectations
         validation_definition = (

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -112,7 +112,7 @@ def create_action_list(
 
 def get_or_add_checkpoint(
     validation_settings_obj: ValidationSettings,
-    validation_definitions_list: List[ValidationDefinition],
+    validation_definition: ValidationDefinition,
 ) -> Checkpoint:
     try:
         checkpoint = validation_settings_obj.data_context.checkpoints.get(
@@ -123,8 +123,8 @@ def get_or_add_checkpoint(
             validation_settings_obj=validation_settings_obj
         )
         checkpoint = Checkpoint(
-            name=str(validation_settings_obj.checkpoint_name),
-            validation_definitions=validation_definitions_list,
+            name=validation_settings_obj.checkpoint_name,
+            validation_definitions=[validation_definition],
             action_list=action_list,
         )  # Note: a checkpoint combines validations with actions
 
@@ -198,7 +198,7 @@ def validate(
     print(validation_definition.run(batch_parameters={"dataframe": df}))
     checkpoint = get_or_add_checkpoint(
         validation_settings_obj=validation_settings_obj,
-        validation_definitions_list=[validation_definition],
+        validation_definition=validation_definition,
     )
 
     batch_params = {"dataframe": df}

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -4,6 +4,7 @@ import great_expectations
 import humps
 from great_expectations import ValidationDefinition
 from great_expectations.checkpoint import Checkpoint
+from great_expectations.checkpoint.actions import CheckpointAction
 from great_expectations.checkpoint.checkpoint import CheckpointResult
 from great_expectations.exceptions import DataContextError
 from pyspark.sql import DataFrame
@@ -81,7 +82,7 @@ def get_or_add_validation_definition(
 
 def create_action_list(
     validation_settings_obj: ValidationSettings,
-) -> List[dict[str, Any]]:
+) -> List[CheckpointAction]:
     action_list = list()
 
     # action_list.append(

--- a/src/dq_suite/df_checker.py
+++ b/src/dq_suite/df_checker.py
@@ -74,9 +74,6 @@ def create_action_list(
 ) -> List[CheckpointAction]:
     action_list = list()
 
-    # action_list.append(great_expectations.checkpoint.UpdateDataDocsAction(
-    #     name="update_data_docs"))
-
     if validation_settings_obj.send_slack_notification & (
         validation_settings_obj.slack_webhook is not None
     ):

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -55,7 +55,7 @@ def extract_dq_validatie_data(
 
     # Access run_time attribute
     # run_time = dq_result["meta"]["run_id"].run_time
-    run_time = datetime.date(1900, 1, 1)
+    run_time = datetime.datetime(1900, 1, 1)
     # TODO: fix, find run_time in new GX API
     # Extracted data
     extracted_data = []
@@ -118,7 +118,7 @@ def extract_dq_afwijking_data(
 
     # Extracting information from the JSON
     # run_time = dq_result["meta"]["run_id"].run_time
-    run_time = datetime.date(1900, 1, 1)
+    run_time = datetime.datetime(1900, 1, 1)
     # TODO: fix, find run_time in new GX API
     # Extracted data for df
     extracted_data = []

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -1,5 +1,6 @@
 from typing import Any, List
 
+from great_expectations.checkpoint.checkpoint import CheckpointDescriptionDict
 from pyspark.sql import DataFrame, Row, SparkSession
 from pyspark.sql.functions import col
 from pyspark.sql.types import StructType
@@ -320,7 +321,7 @@ def write_non_validation_tables(
 
 
 def write_validation_table(
-    validation_output: Any,
+    validation_output: CheckpointDescriptionDict,
     validation_settings_obj: ValidationSettings,
     df: DataFrame,
     unique_identifier: str,

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -326,19 +326,20 @@ def write_validation_table(
     df: DataFrame,
     unique_identifier: str,
 ):
-    for results in validation_output.values():
-        result = results["validation_results"]
-        extract_dq_validatie_data(
-            validation_settings_obj.table_name,
-            result,
-            validation_settings_obj.catalog_name,
-            validation_settings_obj.spark_session,
-        )
-        extract_dq_afwijking_data(
-            validation_settings_obj.table_name,
-            result,
-            df,
-            unique_identifier,
-            validation_settings_obj.catalog_name,
-            validation_settings_obj.spark_session,
-        )
+    for k, v in validation_output.items():
+        if k == "validation_results":
+            result = v
+            extract_dq_validatie_data(
+                validation_settings_obj.table_name,
+                result,
+                validation_settings_obj.catalog_name,
+                validation_settings_obj.spark_session,
+            )
+            extract_dq_afwijking_data(
+                validation_settings_obj.table_name,
+                result,
+                df,
+                unique_identifier,
+                validation_settings_obj.catalog_name,
+                validation_settings_obj.spark_session,
+            )

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -327,7 +327,7 @@ def write_validation_table(
     unique_identifier: str,
 ):
     for results in validation_output.values():
-        result = results["validation_result"]
+        result = results["validation_results"]
         extract_dq_validatie_data(
             validation_settings_obj.table_name,
             result,

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -53,7 +53,7 @@ def extract_dq_validatie_data(
     """
     # Access run_time attribute
     # run_time = dq_result["meta"]["run_id"].run_time
-    run_time = datetime.date(1900, 0, 0)
+    run_time = datetime.date(1900, 1, 1)
     # TODO: fix, find run_time in new GX API
     # Extracted data
     extracted_data = []
@@ -113,7 +113,7 @@ def extract_dq_afwijking_data(
     """
     # Extracting information from the JSON
     # run_time = dq_result["meta"]["run_id"].run_time
-    run_time = datetime.date(1900, 0, 0)
+    run_time = datetime.date(1900, 1, 1)
     # TODO: fix, find run_time in new GX API
     # Extracted data for df
     extracted_data = []

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -50,7 +50,7 @@ def construct_regel_id(
     
 
 def create_parameter_list_from_results(result: dict) -> list[dict]:
-    parameters = result["expectation_config"]["kwargs"]
+    parameters = result["kwargs"]
     parameters.pop("batch_id", None)
     return [parameters]
 
@@ -88,7 +88,7 @@ def extract_dq_validatie_data(
             expectation_type = expectation_result["expectation_type"]
             parameter_list = create_parameter_list_from_results(result=expectation_result)
             attribute = expectation_result["kwargs"].get("column")
-            dq_regel_id = f"{df_name}_{expectation_type}_{attribute}"
+
             output = expectation_result["success"]
             output_text = "success" if output else "failure"
             extracted_data.append(

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, List
+from typing import List
 
 from great_expectations.checkpoint.checkpoint import CheckpointDescriptionDict
 from pyspark.sql import DataFrame, Row, SparkSession
@@ -61,8 +61,12 @@ def extract_dq_validatie_data(
     extracted_data = []
     for validation_result in dq_result:
         for expectation_result in validation_result["expectations"]:
-            element_count = int(expectation_result["result"].get("element_count", 0))
-            unexpected_count = int(expectation_result["result"].get("unexpected_count", 0))
+            element_count = int(
+                expectation_result["result"].get("element_count", 0)
+            )
+            unexpected_count = int(
+                expectation_result["result"].get("unexpected_count", 0)
+            )
             aantal_valide_records = element_count - unexpected_count
             expectation_type = expectation_result["expectation_type"]
             attribute = expectation_result["kwargs"].get("column")

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -30,7 +30,9 @@ def list_of_dicts_to_df(
         return create_empty_dataframe(
             spark_session=spark_session, schema=schema
         )
-    return spark_session.createDataFrame((Row(**x) for x in list_of_dicts), schema=schema)
+    return spark_session.createDataFrame(
+        (Row(**x) for x in list_of_dicts), schema=schema
+    )
 
 
 def extract_dq_validatie_data(


### PR DESCRIPTION
The GX API was modified significantly. Main changes to our project include: 

- Downgrade of Python version to 3.11 in `github-ci.yml`, due to compatibility with GX
- Add `pyhumps` library to help with pascal/snake case issues
- Rewrite of most of `df_checker.py` to ensure compatibility with new GX API
- Quick-fix to `output_transformations.py` to handle the modified structure of checkpoint results