### PR TITLE
Parametrise writing to unity catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # About dq-suite-amsterdam
 This repository aims to be an easy-to-use wrapper for the data quality library [Great Expectations](https://github.com/great-expectations/great_expectations) (GX). All that is needed to get started is an in-memory Spark dataframe and a set of data quality rules - specified in a JSON file [of particular formatting](dq_rules_example.json). 
 
-By default, the results of all validations are written to a `data_quality` schema in Unity Catalog, which one has to create once per catalog via [this notebook](scripts/data_quality_tables.sql). Alternatively, one could suppress the writing to UC. Additionally, users can choose to get notified via Slack or Microsoft Teams.
+By default, none of the validation results are written to Unity Catalog. Alternatively, one could allow for writing to a `data_quality` schema in UC, which one has to create once per catalog via [this notebook](scripts/data_quality_tables.sql). Additionally, users can choose to get notified via Slack or Microsoft Teams.
 
 <img src="docs/wip_computer.jpg" width="20%" height="auto">
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # About dq-suite-amsterdam
 This repository aims to be an easy-to-use wrapper for the data quality library [Great Expectations](https://github.com/great-expectations/great_expectations) (GX). All that is needed to get started is an in-memory Spark dataframe and a set of data quality rules - specified in a JSON file [of particular formatting](dq_rules_example.json). 
 
-While the results of all validations are written to a `data_quality` schema in Unity Catalog, users can also choose to get notified via Slack or Microsoft Teams.
+By default, the results of all validations are written to a `data_quality` schema in Unity Catalog, which one has to create once per catalog via [this notebook](scripts/data_quality_tables.sql). Alternatively, one could suppress the writing to UC. Additionally, users can choose to get notified via Slack or Microsoft Teams.
 
 <img src="docs/wip_computer.jpg" width="20%" height="auto">
 
@@ -47,7 +47,7 @@ run_validation(
     validation_name="my_validation_name",
 )
 ```
-See the documentation of `dq_suite.validation.run` for what other parameters can be passed.
+See the documentation of `dq_suite.validation.run_validation` for what other parameters can be passed.
 
 
 # Other functionalities

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ run_validation(
     spark_session=spark,
     catalog_name=catalog_name,
     table_name=table_name,
-    validation_name="my_validation_name",
 )
 ```
 See the documentation of `dq_suite.validation.run_validation` for what other parameters can be passed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dq-suite-amsterdam"
-version = "0.11.7"
+version = "0.11.8"
 authors = [
   { name="Arthur Kordes", email="a.kordes@amsterdam.nl" },
   { name="Aysegul Cayir Aydar", email="a.cayiraydar@amsterdam.nl" },

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -299,6 +299,7 @@ def run_validation(
     slack_webhook: str | None = None,
     ms_teams_webhook: str | None = None,
     notify_on: Literal["all", "success", "failure"] = "failure",
+    write_results_to_unity_catalog: bool = True,
 ) -> None:  # pragma: no cover - only GX functions
     """
     Main function for users of dq_suite.
@@ -360,15 +361,16 @@ def run_validation(
     run_time = datetime.datetime.now()  # TODO: get from RunIdentifier object
 
     # 3) ... and write results to unity catalog
-    write_non_validation_tables(
-        dq_rules_dict=validation_dict,
-        validation_settings_obj=validation_settings_obj,
-    )
-    write_validation_table(
-        validation_output=validation_output,
-        validation_settings_obj=validation_settings_obj,
-        df=df,
-        dataset_name=validation_dict["dataset"]["name"],
-        unique_identifier=rules_dict["unique_identifier"],
-        run_time=run_time,
-    )
+    if write_results_to_unity_catalog:
+        write_non_validation_tables(
+            dq_rules_dict=validation_dict,
+            validation_settings_obj=validation_settings_obj,
+        )
+        write_validation_table(
+            validation_output=validation_output,
+            validation_settings_obj=validation_settings_obj,
+            df=df,
+            dataset_name=validation_dict["dataset"]["name"],
+            unique_identifier=rules_dict["unique_identifier"],
+            run_time=run_time,
+        )

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -294,7 +294,7 @@ def run_validation(
     spark_session: SparkSession,
     catalog_name: str,
     table_name: str,
-    validation_name: str,
+    validation_name: str = "my_validation_name",
     data_context_root_dir: str = "/dbfs/great_expectations/",
     slack_webhook: str | None = None,
     ms_teams_webhook: str | None = None,

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -299,7 +299,7 @@ def run_validation(
     slack_webhook: str | None = None,
     ms_teams_webhook: str | None = None,
     notify_on: Literal["all", "success", "failure"] = "failure",
-    write_results_to_unity_catalog: bool = True,
+    write_results_to_unity_catalog: bool = False,
 ) -> None:  # pragma: no cover - only GX functions
     """
     Main function for users of dq_suite.

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -320,6 +320,7 @@ def run_validation(
         an MS Teams notification will be sent
     notify_on: when to send notifications, can be equal to "all",
         "success" or "failure"
+    write_results_to_unity_catalog: toggle writing of results to UC
     """
     validation_settings_obj = ValidationSettings(
         spark_session=spark_session,


### PR DESCRIPTION
- Add boolean `write_results_to_unity_catalog`, set default value to `False`
- Simplify usage of `run_validation` function
- Update readme