### PR TITLE
Issue/86 return checkpoint result

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # About dq-suite-amsterdam
 This repository aims to be an easy-to-use wrapper for the data quality library [Great Expectations](https://github.com/great-expectations/great_expectations) (GX). All that is needed to get started is an in-memory Spark dataframe and a set of data quality rules - specified in a JSON file [of particular formatting](dq_rules_example.json). 
 
-By default, none of the validation results are written to Unity Catalog. Alternatively, one could allow for writing to a `data_quality` schema in UC, which one has to create once per catalog via [this notebook](scripts/data_quality_tables.sql). Additionally, users can choose to get notified via Slack or Microsoft Teams.
+By default, all the validation results are written to Unity Catalog. Alternatively, one could disallow writing to a `data_quality` schema in UC, which one has to create once per catalog via [this notebook](scripts/data_quality_tables.sql). Additionally, users can choose to get notified via Slack or Microsoft Teams.
 
 <img src="docs/wip_computer.jpg" width="20%" height="auto">
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dq-suite-amsterdam"
-version = "0.11.10"
+version = "0.11.11"
 authors = [
   { name="Arthur Kordes", email="a.kordes@amsterdam.nl" },
   { name="Aysegul Cayir Aydar", email="a.cayiraydar@amsterdam.nl" },

--- a/src/dq_suite/other.py
+++ b/src/dq_suite/other.py
@@ -89,7 +89,9 @@ def get_all_table_name_to_column_names_mappings(
     return list_of_all_table_name_to_column_names_mappings
 
 
-def export_schema_to_json_string(dataset: str, spark: SparkSession, *table: str) -> str:
+def export_schema_to_json_string(
+    dataset: str, spark: SparkSession, *table: str
+) -> str:
     """
     Function exports a schema from Unity Catalog to be used by the Excel
     input form
@@ -104,8 +106,8 @@ def export_schema_to_json_string(dataset: str, spark: SparkSession, *table: str)
         table_name_list = table
     else:
         table_name_list = get_table_name_list_from_unity_catalog(
-        dataset=dataset, spark=spark
-    )
+            dataset=dataset, spark=spark
+        )
 
     df_columns_tables = create_dataframe_containing_all_column_names_in_tables(
         table_name_list=table_name_list, spark=spark

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -37,8 +37,10 @@ def convert_param_values_to_float(parameters):
     """
     float_list = ["min_value", "max_value"]
     for k, v in parameters.items():
-        if k in float_list: v = round(float(v), 1)
+        if k in float_list:
+            v = round(float(v), 1)
         parameters[k] = v
+
 
 def create_empty_dataframe(
     spark_session: SparkSession, schema: StructType

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -372,6 +372,9 @@ def run_validation(
         validation_settings_obj=validation_settings_obj,
     )
 
+    if debug_mode:  # Don't write to UC in debug mode
+        return checkpoint_result.success, checkpoint_result
+
     # 3) ... and write results to unity catalog
     if write_results_to_unity_catalog:
         validation_output = checkpoint_result.describe_dict()
@@ -390,6 +393,4 @@ def run_validation(
             unique_identifier=rules_dict["unique_identifier"],
             run_time=run_time,
         )
-    if debug_mode:
-        return checkpoint_result.success, checkpoint_result
     return checkpoint_result.success

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -140,12 +140,11 @@ class ValidationRunner:
         gx_expectation_class = getattr(gx_core, gx_expectation_name)
 
         gx_expectation_parameters: dict = validation_rule["parameters"]
-        if "column" not in gx_expectation_parameters.keys():
-            gx_expectation_parameters["column"] = None
+        column_name = gx_expectation_parameters.get("column", None)
 
         gx_expectation_parameters["meta"] = {
             "table_name": table_name,
-            "column_name": gx_expectation_parameters['column'],
+            "column_name": column_name,
             "expectation_name": gx_expectation_name
         }
         return gx_expectation_class(**gx_expectation_parameters)

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -331,9 +331,9 @@ def run_validation(
         an MS Teams notification will be sent
     notify_on: when to send notifications, can be equal to "all",
         "success" or "failure"
-    write_results_to_unity_catalog: toggle writing of results to UC
-    debug_mode: toggle returning of CheckpointResult, in addition to a
-    boolean flag
+    write_results_to_unity_catalog: by default (True) write results to UC
+    debug_mode: default (False) returns a boolean flag, alternatively (True)
+        a tuple containing boolean flag and CheckpointResult object is returned
     """
     validation_settings_obj = ValidationSettings(
         spark_session=spark_session,

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -213,7 +213,6 @@ class ValidationRunner:
                     "module_name": "great_expectations.render.renderer.slack_renderer",
                     "class_name": "SlackRenderer",
                 },
-                show_failed_expectations=True
             )
         )
 
@@ -229,7 +228,6 @@ class ValidationRunner:
                     "module_name": "great_expectations.render.renderer.microsoft_teams_renderer",
                     "class_name": "MicrosoftTeamsRenderer",
                 },
-                show_failed_expectations=True
             )
         )
 

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -205,6 +205,7 @@ class ValidationRunner:
                     "module_name": "great_expectations.render.renderer.slack_renderer",
                     "class_name": "SlackRenderer",
                 },
+                show_failed_expectations=True
             )
         )
 
@@ -220,6 +221,7 @@ class ValidationRunner:
                     "module_name": "great_expectations.render.renderer.microsoft_teams_renderer",
                     "class_name": "MicrosoftTeamsRenderer",
                 },
+                show_failed_expectations=True
             )
         )
 

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, List, Literal
+from typing import Dict, List, Literal, Tuple
 
 from great_expectations import (
     Checkpoint,
@@ -309,7 +309,9 @@ def run_validation(
     ms_teams_webhook: str | None = None,
     notify_on: Literal["all", "success", "failure"] = "failure",
     write_results_to_unity_catalog: bool = True,
-) -> CheckpointResult:  # pragma: no cover - only GX functions
+    debug_mode: bool = False,
+) -> bool | Tuple[bool, CheckpointResult]:  # pragma: no cover - only GX
+    # functions
     """
     Main function for users of dq_suite.
 
@@ -330,6 +332,8 @@ def run_validation(
     notify_on: when to send notifications, can be equal to "all",
         "success" or "failure"
     write_results_to_unity_catalog: toggle writing of results to UC
+    debug_mode: toggle returning of CheckpointResult, in addition to a
+    boolean flag
     """
     validation_settings_obj = ValidationSettings(
         spark_session=spark_session,
@@ -386,5 +390,6 @@ def run_validation(
             unique_identifier=rules_dict["unique_identifier"],
             run_time=run_time,
         )
-
-    return checkpoint_result
+    if debug_mode:
+        return checkpoint_result.success, checkpoint_result
+    return checkpoint_result.success

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -131,7 +131,7 @@ class ValidationRunner:
         return suite
 
     @staticmethod
-    def _get_gx_expectation_object(validation_rule: Rule):
+    def _get_gx_expectation_object(validation_rule: Rule, table_name: str):
         """
         From great_expectations.expectations.core, get the relevant class and
         instantiate an expectation object with the user-defined parameters
@@ -140,7 +140,11 @@ class ValidationRunner:
         gx_expectation_class = getattr(gx_core, gx_expectation_name)
 
         gx_expectation_parameters: dict = validation_rule["parameters"]
-        gx_expectation_parameters["meta"] = {"name": f"testing {gx_expectation_name}"}
+        if "column" not in gx_expectation_parameters.keys():
+            gx_expectation_parameters["column"] = None
+        expectation_meta_data_identifier = \
+            f"{table_name}_{gx_expectation_parameters['column']}_{gx_expectation_name}"
+        gx_expectation_parameters["meta"] = {"identifier": expectation_meta_data_identifier}
         return gx_expectation_class(**gx_expectation_parameters)
 
     def add_expectations_to_suite(self, validation_rules_list: List[Rule]):
@@ -149,7 +153,8 @@ class ValidationRunner:
 
         for validation_rule in validation_rules_list:
             gx_expectation_obj = self._get_gx_expectation_object(
-                validation_rule=validation_rule
+                validation_rule=validation_rule,
+                table_name=self.table_name
             )
             expectation_suite_obj.add_expectation(gx_expectation_obj)
 

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -140,6 +140,7 @@ class ValidationRunner:
         gx_expectation_class = getattr(gx_core, gx_expectation_name)
 
         gx_expectation_parameters: dict = validation_rule["parameters"]
+        gx_expectation_parameters["meta"] = {"name": f"testing {gx_expectation_name}"}
         return gx_expectation_class(**gx_expectation_parameters)
 
     def add_expectations_to_suite(self, validation_rules_list: List[Rule]):

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -358,11 +358,11 @@ def run_validation(
         rules_dict=rules_dict,
         validation_settings_obj=validation_settings_obj,
     )
-    validation_output = checkpoint_result.describe_dict()
-    run_time = datetime.datetime.now()  # TODO: get from RunIdentifier object
 
     # 3) ... and write results to unity catalog
     if write_results_to_unity_catalog:
+        validation_output = checkpoint_result.describe_dict()
+        run_time = datetime.datetime.now()  # TODO: get from RunIdentifier object
         write_non_validation_tables(
             dq_rules_dict=validation_dict,
             validation_settings_obj=validation_settings_obj,

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -145,7 +145,7 @@ class ValidationRunner:
         gx_expectation_parameters["meta"] = {
             "table_name": table_name,
             "column_name": column_name,
-            "expectation_name": gx_expectation_name
+            "expectation_name": gx_expectation_name,
         }
         return gx_expectation_class(**gx_expectation_parameters)
 
@@ -155,8 +155,7 @@ class ValidationRunner:
 
         for validation_rule in validation_rules_list:
             gx_expectation_obj = self._get_gx_expectation_object(
-                validation_rule=validation_rule,
-                table_name=self.table_name
+                validation_rule=validation_rule, table_name=self.table_name
             )
             expectation_suite_obj.add_expectation(gx_expectation_obj)
 
@@ -293,7 +292,9 @@ def validate(
     validation_runner_obj.create_validation_definition()
 
     print("***Starting validation run***")
-    return validation_runner_obj.run_validation(batch_parameters={"dataframe": df})
+    return validation_runner_obj.run_validation(
+        batch_parameters={"dataframe": df}
+    )
 
 
 def run_validation(
@@ -370,7 +371,9 @@ def run_validation(
     # 3) ... and write results to unity catalog
     if write_results_to_unity_catalog:
         validation_output = checkpoint_result.describe_dict()
-        run_time = datetime.datetime.now()  # TODO: get from RunIdentifier object
+        run_time = (
+            datetime.datetime.now()
+        )  # TODO: get from RunIdentifier object
         write_non_validation_tables(
             dq_rules_dict=validation_dict,
             validation_settings_obj=validation_settings_obj,

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -300,7 +300,7 @@ def run_validation(
     ms_teams_webhook: str | None = None,
     notify_on: Literal["all", "success", "failure"] = "failure",
     write_results_to_unity_catalog: bool = True,
-) -> None:  # pragma: no cover - only GX functions
+) -> CheckpointResult:  # pragma: no cover - only GX functions
     """
     Main function for users of dq_suite.
 
@@ -375,3 +375,5 @@ def run_validation(
             unique_identifier=rules_dict["unique_identifier"],
             run_time=run_time,
         )
+
+    return checkpoint_result

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -142,9 +142,12 @@ class ValidationRunner:
         gx_expectation_parameters: dict = validation_rule["parameters"]
         if "column" not in gx_expectation_parameters.keys():
             gx_expectation_parameters["column"] = None
-        expectation_meta_data_identifier = \
-            f"{table_name}_{gx_expectation_parameters['column']}_{gx_expectation_name}"
-        gx_expectation_parameters["meta"] = {"identifier": expectation_meta_data_identifier}
+
+        gx_expectation_parameters["meta"] = {
+            "table_name": table_name,
+            "column_name": gx_expectation_parameters['column'],
+            "expectation_name": gx_expectation_name
+        }
         return gx_expectation_class(**gx_expectation_parameters)
 
     def add_expectations_to_suite(self, validation_rules_list: List[Rule]):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -99,7 +99,8 @@ class TestValidationRunner:
             )
 
             validation_runner_obj._get_gx_expectation_object(
-                validation_rule=the_rule
+                validation_rule=the_rule,
+                table_name="the_table"
             )
 
     def test_get_gx_expectation_object(self, validation_runner_obj):
@@ -109,7 +110,8 @@ class TestValidationRunner:
         )
         the_expectation_object = (
             validation_runner_obj._get_gx_expectation_object(
-                validation_rule=the_rule
+                validation_rule=the_rule,
+                table_name="the_table"
             )
         )
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -99,8 +99,7 @@ class TestValidationRunner:
             )
 
             validation_runner_obj._get_gx_expectation_object(
-                validation_rule=the_rule,
-                table_name="the_table"
+                validation_rule=the_rule, table_name="the_table"
             )
 
     def test_get_gx_expectation_object(self, validation_runner_obj):
@@ -110,8 +109,7 @@ class TestValidationRunner:
         )
         the_expectation_object = (
             validation_runner_obj._get_gx_expectation_object(
-                validation_rule=the_rule,
-                table_name="the_table"
+                validation_rule=the_rule, table_name="the_table"
             )
         )
 


### PR DESCRIPTION
This PR generalises the original idea of `run_validation` returning flags: by default, a boolean indicating success will be returned by  `run_validation` - however, in `debug_mode`, it return an additional `CheckpointResult`, so the user can dig into this for further details. 

Also, a `'meta'` key was added to each GX expectation, containing table name, column name and expectation name. These values can be used from the `CheckpointResult` and could be of use when writing a custom SlackAction in future (containing information about which expectation on which column of which table is failing). 