### PR TITLE
Issue/92 more detailed slack notification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dq-suite-amsterdam"
-version = "0.11.11"
+version = "0.11.12"
 authors = [
   { name="Arthur Kordes", email="a.kordes@amsterdam.nl" },
   { name="Aysegul Cayir Aydar", email="a.cayiraydar@amsterdam.nl" },

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -300,6 +300,7 @@ class ValidationSettings:
         self._batch_definition_name = f"{self.batch_name}"
 
     def _set_expectation_suite_name(self):
+        # TODO: remove conditional once CustomSlackRenderer is implemented?
         if self.batch_name is not None:
             self._expectation_suite_name = (
                 f"batch-{self._batch_definition_name}"

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -278,15 +278,17 @@ class ValidationSettings:
         )
 
     def _set_checkpoint_name(self):
-        self._checkpoint_name = (f"{self.dataset_layer}/"
-                                 f"{self.dataset_name}/{self.table_name}")
+        self._checkpoint_name = (
+            f"{self.dataset_layer}/" f"{self.dataset_name}/{self.table_name}"
+        )
 
     def _set_run_name(self):
         self._run_name = f"%Y%m%d-%H%M%S-{self.validation_name}"
 
     def _set_data_source_name(self):
-        self._data_source_name = (f"{self.catalog_name}/{self.dataset_layer}"
-                                  f"{self.dataset_name}")
+        self._data_source_name = (
+            f"{self.catalog_name}/{self.dataset_layer}" f"{self.dataset_name}"
+        )
 
     def _set_validation_definition_name(self):
         self._validation_definition_name = (

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -278,13 +278,15 @@ class ValidationSettings:
         )
 
     def _set_checkpoint_name(self):
-        self._checkpoint_name = f"{self.validation_name}_checkpoint"
+        self._checkpoint_name = (f"{self.dataset_layer}/"
+                                 f"{self.dataset_name}/{self.table_name}")
 
     def _set_run_name(self):
         self._run_name = f"%Y%m%d-%H%M%S-{self.validation_name}"
 
     def _set_data_source_name(self):
-        self._data_source_name = f"spark_data_source_{self.validation_name}"
+        self._data_source_name = (f"{self.catalog_name}/{self.dataset_layer}"
+                                  f"{self.dataset_name}")
 
     def _set_validation_definition_name(self):
         self._validation_definition_name = (

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -209,6 +209,9 @@ class ValidationSettings:
 
     spark_session: SparkSession object
     catalog_name: name of unity catalog
+    dataset_layer: name of layer where dataset is located: landing_zone,
+    bronze, silver, gold
+    dataset_name: data set (source system) name
     table_name: name of table in unity catalog
     validation_name: name of data quality check
     data_context_root_dir: path to write GX data
@@ -223,6 +226,8 @@ class ValidationSettings:
 
     spark_session: SparkSession
     catalog_name: str
+    dataset_layer: str
+    dataset_name: str
     table_name: str
     validation_name: str
     data_context_root_dir: str = "/dbfs/great_expectations/"
@@ -235,6 +240,10 @@ class ValidationSettings:
             raise TypeError("'spark_session' should be of type SparkSession")
         if not isinstance(self.catalog_name, str):
             raise TypeError("'catalog_name' should be of type str")
+        if not isinstance(self.dataset_layer, str):
+            raise TypeError("'dataset_layer' should be of type str")
+        if not isinstance(self.dataset_name, str):
+            raise TypeError("'dataset_name' should be of type str")
         if not isinstance(self.table_name, str):
             raise TypeError("'table_name' should be of type str")
         if not isinstance(self.validation_name, str):

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -286,9 +286,7 @@ class ValidationSettings:
         self._run_name = f"%Y%m%d-%H%M%S-{self.validation_name}"
 
     def _set_data_source_name(self):
-        self._data_source_name = (
-            f"{self.catalog_name}/{self.dataset_layer}"
-        )
+        self._data_source_name = f"{self.catalog_name}/{self.dataset_layer}"
 
     def _set_data_asset_name(self):
         self._data_asset_name = self.dataset_name
@@ -303,7 +301,9 @@ class ValidationSettings:
 
     def _set_expectation_suite_name(self):
         if self.batch_name is not None:
-            self._expectation_suite_name = f"batch-{self._batch_definition_name}"
+            self._expectation_suite_name = (
+                f"batch-{self._batch_definition_name}"
+            )
         else:
             self._expectation_suite_name = (
                 f"{self.validation_name}_expectation_suite"

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -251,7 +251,8 @@ class ValidationSettings:
         if not isinstance(self.validation_name, str):
             raise TypeError("'validation_name' should be of type str")
         if not isinstance(self.batch_name, str):
-            raise TypeError("'batch_name' should be of type str")
+            if self.batch_name is not None:
+                raise TypeError("'batch_name' should be of type str")
         if not isinstance(self.data_context_root_dir, str):
             raise TypeError("'data_context_root_dir' should be of type str")
         if not isinstance(self.slack_webhook, str):

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -269,6 +269,7 @@ class ValidationSettings:
         self._set_checkpoint_name()
         self._set_run_name()
         self._set_data_source_name()
+        self._set_data_asset_name()
         self._set_validation_definition_name()
         self._set_batch_definition_name()
 
@@ -279,7 +280,7 @@ class ValidationSettings:
 
     def _set_checkpoint_name(self):
         self._checkpoint_name = (
-            f"{self.dataset_layer}/" f"{self.dataset_name}/{self.table_name}"
+            f"{self.dataset_layer}/{self.dataset_name}/{self.table_name}"
         )
 
     def _set_run_name(self):
@@ -289,6 +290,9 @@ class ValidationSettings:
         self._data_source_name = (
             f"{self.catalog_name}/{self.dataset_layer}" f"{self.dataset_name}"
         )
+
+    def _set_data_asset_name(self):
+        self._data_asset_name = self.dataset_name
 
     def _set_validation_definition_name(self):
         self._validation_definition_name = (

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -214,6 +214,7 @@ class ValidationSettings:
     dataset_name: data set (source system) name
     table_name: name of table in unity catalog
     validation_name: name of data quality check
+    batch_name: name of the batch to validate
     data_context_root_dir: path to write GX data
     context - default "/dbfs/great_expectations/"
     slack_webhook: webhook, recommended to store in key vault. If not None,
@@ -230,6 +231,7 @@ class ValidationSettings:
     dataset_name: str
     table_name: str
     validation_name: str
+    batch_name: str | None = None
     data_context_root_dir: str = "/dbfs/great_expectations/"
     slack_webhook: str | None = None
     ms_teams_webhook: str | None = None
@@ -248,6 +250,8 @@ class ValidationSettings:
             raise TypeError("'table_name' should be of type str")
         if not isinstance(self.validation_name, str):
             raise TypeError("'validation_name' should be of type str")
+        if not isinstance(self.batch_name, str):
+            raise TypeError("'batch_name' should be of type str")
         if not isinstance(self.data_context_root_dir, str):
             raise TypeError("'data_context_root_dir' should be of type str")
         if not isinstance(self.slack_webhook, str):
@@ -265,18 +269,13 @@ class ValidationSettings:
     def _initialise_or_update_name_parameters(self):
         # TODO/check: nearly all names are related to 'validation_name' - do we want
         #  to allow for custom names via parameters?
-        self._set_expectation_suite_name()
         self._set_checkpoint_name()
         self._set_run_name()
         self._set_data_source_name()
         self._set_data_asset_name()
         self._set_validation_definition_name()
         self._set_batch_definition_name()
-
-    def _set_expectation_suite_name(self):
-        self._expectation_suite_name = (
-            f"{self.validation_name}_expectation_suite"
-        )
+        self._set_expectation_suite_name()
 
     def _set_checkpoint_name(self):
         self._checkpoint_name = (
@@ -300,4 +299,12 @@ class ValidationSettings:
         )
 
     def _set_batch_definition_name(self):
-        self._batch_definition_name = f"{self.validation_name}_batch_definition"
+        self._batch_definition_name = f"{self.batch_name}"
+
+    def _set_expectation_suite_name(self):
+        if self.batch_name is not None:
+            self._expectation_suite_name = f"batch-{self._batch_definition_name}"
+        else:
+            self._expectation_suite_name = (
+                f"{self.validation_name}_expectation_suite"
+            )

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -288,7 +288,7 @@ class ValidationSettings:
 
     def _set_data_source_name(self):
         self._data_source_name = (
-            f"{self.catalog_name}/{self.dataset_layer}" f"{self.dataset_name}"
+            f"{self.catalog_name}/{self.dataset_layer}"
         )
 
     def _set_data_asset_name(self):

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -41,22 +41,16 @@ class CustomSlackNotificationAction(SlackNotificationAction):
             for result in suite_validation_result.results:
                 if not result.success:
                     expectation_info = result["expectation_config"]["meta"]
+                    results = result.result
                     summary_text += (
                         f"""
                         \n *Column*: {expectation_info['column_name']}\n 
 *Expectation*: {expectation_info['expectation_name']}\n
+*Sample unexpected values*:  {results['partial_unexpected_list'][:3]}\n
+*Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
+"-----------------------\n"
                         """
                     )
-
-                    results = result.result
-                    summary_text += (
-                        f"""
-                        \n *Sample unexpected values*:  {results['partial_unexpected_list'][:3]}\n
-                        *Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
-                        """
-                    )
-
-                    summary_text += "-----------------------\n"
 
         validation_text_blocks[0]["text"]["text"] = summary_text
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -110,7 +110,8 @@ class CustomSlackNotificationAction(SlackNotificationAction):
             if not validation_result_suite.success:
                 for result in validation_result_suite.results:
                     if not result.success:
-                        expectation_info = result.expectation_config.meta
+                        print(result)
+                        expectation_info = result['expectation_config']['meta']
                         summary_text += (f"*Table*:"
                                          f" {expectation_info['table_name']} / "
                                          f"*Column*:"

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -43,20 +43,16 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                     expectation_info = result["expectation_config"]["meta"]
                     summary_text += (
                         f"""
-                        \n *Column*:
-                         {expectation_info['column_name']} / 
-                        *Expectation*:
-                         {expectation_info['expectation_name']}\n
+                        \n *Column*: {expectation_info['column_name']}\n 
+                        *Expectation*: {expectation_info['expectation_name']}\n
                         """
                     )
 
                     results = result.result
                     summary_text += (
                         f"""
-                        \n *Sample unexpected values*: 
-                        {results['partial_unexpected_list'][:3]}
-                         / *Unexpected / total count*: 
-                        {results['unexpected_count']} / {results['element_count']}\n
+                        \n *Sample unexpected values*:  {results['partial_unexpected_list'][:3]}\n
+                        *Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
                         """
                     )
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -104,6 +104,29 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                 action_context=action_context,
             )
             print(validation_text_blocks)
+
+            # Add sample of unexpected values
+            summary_text = validation_text_blocks[0]["text"]["text"]
+            if not validation_result_suite.success:
+                for result in validation_result_suite.results:
+                    if not result.success:
+                        expectation_info = result.expectation_config.meta
+                        summary_text += (f"*Table*:"
+                                         f" {expectation_info['table_name']} / "
+                                         f"*Column*:"
+                                         f" {expectation_info['column_name']} /  "
+                                         f"*Expectation*:"
+                                         f" {expectation_info['expectation_name']}\\n")
+
+                        results = result.result
+                        summary_text += (f"*Sample unexpected values*: "
+                                         f"{results['partial_unexpected_list'][:3]}"
+                                         f" / *Unexpected percentage*: "
+                                         f"{results['unexpected_percent_total']}"
+                                         )
+
+            print(validation_text_blocks)
+
             checkpoint_text_blocks.extend(validation_text_blocks)
 
         payload = self.renderer.concatenate_text_blocks(

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -47,7 +47,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
 :information_source: Details:
 *Sample unexpected values*:  ```{results['partial_unexpected_list'][:3]}```\n
 *Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
-*Expectation parameters*: {parameters}\n
+*Expectation parameters*: `{parameters}`\n
 -----------------------\n
             """
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -36,7 +36,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
 
         # Add sample of unexpected values
         summary_text = validation_text_blocks[0]["text"]["text"]
-        summary_text += "\n-----------------------\n"
+        summary_text += "\n-----------------------"
         if not suite_validation_result.success:
             for result in suite_validation_result.results:
                 if not result.success:
@@ -48,7 +48,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
 *Expectation*: {expectation_info['expectation_name']}\n
 *Sample unexpected values*:  {results['partial_unexpected_list'][:3]}\n
 *Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
-"-----------------------\n"
+-----------------------\n
                         """
                     )
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -103,6 +103,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                 result=validation_result_suite,
                 action_context=action_context,
             )
+            print(validation_text_blocks)
             checkpoint_text_blocks.extend(validation_text_blocks)
 
         payload = self.renderer.concatenate_text_blocks(

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -1,11 +1,24 @@
 from great_expectations.checkpoint import SlackNotificationAction
-from great_expectations.checkpoint.actions import ActionContext, _should_notify
+from great_expectations.checkpoint.actions import ActionContext
 from great_expectations.checkpoint.checkpoint import CheckpointResult
+
+from typing import Literal
 
 # https://medium.com/@jojo-data/how-to-create-a-custom-module-in-great-expectations-efd0a6ed704a
 
 
 class CustomSlackNotificationAction(SlackNotificationAction):
+    @staticmethod
+    def _should_notify(success: bool,
+                       notify_on: Literal["all", "failure", "success"]) -> bool:
+        return (
+                notify_on == "all"
+                or notify_on == "success"
+                and success
+                or notify_on == "failure"
+                and not success
+        )
+
     # @override
     def run(
         self,
@@ -16,7 +29,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
         checkpoint_name = checkpoint_result.checkpoint_config.name
         result = {"slack_notification_result": "none required"}
 
-        if not _should_notify(success=success, notify_on=self.notify_on):
+        if not self._should_notify(success=success, notify_on=self.notify_on):
             return result
 
         checkpoint_text_blocks: list[dict] = []

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -1,4 +1,4 @@
-from typing import Literal, override
+from typing import Literal
 
 from great_expectations.checkpoint.actions import ActionContext, _should_notify
 from great_expectations.checkpoint.checkpoint import CheckpointResult
@@ -81,7 +81,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
     type: Literal["custom_slack"] = "custom_slack"
     renderer: CustomSlackRenderer = Field(default_factory=CustomSlackRenderer)
 
-    @override
+    # @override
     def run(
             self, checkpoint_result: CheckpointResult,
             action_context: ActionContext | None = None

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -44,8 +44,8 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                     results = result.result
                     summary_text += (
                         f"""
-\n *Column*: `{expectation_info['column_name']}`, *Expectation*: `{expectation_info['expectation_name']}`\n
-:information_source: Additional information
+\n *Column*: `{expectation_info['column_name']}`    *Expectation*: `{expectation_info['expectation_name']}`\n\n
+:information_source: Details:
 *Sample unexpected values*:  {results['partial_unexpected_list'][:3]}\n
 *Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
 -----------------------\n

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -34,7 +34,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
             action_context=action_context,
         )
 
-        # Add sample of unexpected values
+        # Add sample of unexpected values + metadata
         summary_text = validation_text_blocks[0]["text"]["text"]
         summary_text += "\n-----------------------"
         if not suite_validation_result.success:
@@ -53,6 +53,9 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                     )
 
         validation_text_blocks[0]["text"]["text"] = summary_text
+        validation_text_blocks[0]["text"]["type"] = "mrkdwn"
+
+        # summary_text += "-----------------------\n"
 
         return validation_text_blocks
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -12,6 +12,11 @@ from great_expectations.data_context.types.resource_identifiers import (
 )
 
 
+class CustomSlackRenderer:
+    # TODO: implement. Should at least allow for a custom header
+    pass
+
+
 class CustomSlackNotificationAction(SlackNotificationAction):
     @staticmethod
     def _should_notify(
@@ -61,7 +66,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
             result_identifier=validation_result_identifier,
             result=suite_validation_result,
             action_context=action_context,
-        )
+        )  # TODO: implement custom SlackRenderer-class (above)
 
         result_text_block = validation_text_blocks[0]["text"]["text"]
         result_text_block += "\n-----------------------"

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -47,7 +47,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
         return f"""
 \n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_metadata['expectation_name']}`\n\n
 :information_source: Details:
-*Sample unexpected values*:  {results['partial_unexpected_list'][:3]}\n
+*Sample unexpected values*:  ```{results['partial_unexpected_list'][:3]}```\n
 *Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
 *Expectation parameters*: {parameters}\n
 -----------------------\n

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -79,7 +79,7 @@ class CustomSlackRenderer(SlackRenderer):
 
 class CustomSlackNotificationAction(SlackNotificationAction):
     type: Literal["custom_slack"] = "custom_slack"
-    renderer: CustomSlackRenderer = Field(default_factory=CustomSlackRenderer)
+    # renderer: CustomSlackRenderer = Field(default_factory=CustomSlackRenderer)
 
     # @override
     def run(

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -126,6 +126,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                                          f"{results['unexpected_percent_total']}"
                                          )
 
+            validation_text_blocks[0]["text"]["text"] = summary_text
             print(validation_text_blocks)
 
             checkpoint_text_blocks.extend(validation_text_blocks)

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -43,13 +43,13 @@ class CustomSlackNotificationAction(SlackNotificationAction):
 
         return (
             f"""
-        \n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_metadata['expectation_name']}`\n\n
-        :information_source: Details:
-        *Sample unexpected values*:  {results['partial_unexpected_list'][:3]}\n
-        *Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
-        *Expectation parameters*: {parameters}\n
-        -----------------------\n
-                                """
+\n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_metadata['expectation_name']}`\n\n
+:information_source: Details:
+*Sample unexpected values*:  {results['partial_unexpected_list'][:3]}\n
+*Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
+*Expectation parameters*: {parameters}\n
+-----------------------\n
+            """
         )
 
     def _get_validation_text_blocks(self, validation_result_identifier:

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -4,6 +4,11 @@ from great_expectations.checkpoint.checkpoint import CheckpointResult
 
 from typing import Literal
 
+from great_expectations.core import ExpectationSuiteValidationResult
+from great_expectations.data_context.types.resource_identifiers import \
+    ValidationResultIdentifier
+
+
 # https://medium.com/@jojo-data/how-to-create-a-custom-module-in-great-expectations-efd0a6ed704a
 
 
@@ -19,14 +24,54 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                 and not success
         )
 
-    # @override
+    def _get_validation_text_blocks(self, validation_result_identifier:
+    ValidationResultIdentifier, suite_validation_result:
+    ExpectationSuiteValidationResult, action_context: ActionContext) -> list[dict]:
+
+        validation_text_blocks = self._render_validation_result(
+            result_identifier=validation_result_identifier,
+            result=suite_validation_result,
+            action_context=action_context,
+        )
+
+        # Add sample of unexpected values
+        summary_text = validation_text_blocks[0]["text"]["text"]
+        summary_text += "\n-----------------------\n"
+        if not suite_validation_result.success:
+            for result in suite_validation_result.results:
+                if not result.success:
+                    expectation_info = result["expectation_config"]["meta"]
+                    summary_text += (
+                        f"""
+                        \n *Column*:
+                         {expectation_info['column_name']} / 
+                        *Expectation*:
+                         {expectation_info['expectation_name']}\n
+                        """
+                    )
+
+                    results = result.result
+                    summary_text += (
+                        f"""
+                        \n *Sample unexpected values*: 
+                        {results['partial_unexpected_list'][:3]}
+                         / *Unexpected / total count*: 
+                        {results['unexpected_count']} / {results['element_count']}\n
+                        """
+                    )
+
+                    summary_text += "-----------------------\n"
+
+        validation_text_blocks[0]["text"]["text"] = summary_text
+
+        return validation_text_blocks
+
     def run(
         self,
         checkpoint_result: CheckpointResult,
         action_context: ActionContext | None = None,
     ) -> dict:
         success = checkpoint_result.success or False
-        checkpoint_name = checkpoint_result.checkpoint_config.name
         result = {"slack_notification_result": "none required"}
 
         if not self._should_notify(success=success, notify_on=self.notify_on):
@@ -34,52 +79,21 @@ class CustomSlackNotificationAction(SlackNotificationAction):
 
         checkpoint_text_blocks: list[dict] = []
         for (
-            validation_result_suite_identifier,
-            validation_result_suite,
+            validation_result_identifier,
+            suite_validation_result,
         ) in checkpoint_result.run_results.items():
-            validation_text_blocks = self._render_validation_result(
-                result_identifier=validation_result_suite_identifier,
-                result=validation_result_suite,
-                action_context=action_context,
+            validation_text_blocks = self._get_validation_text_blocks(
+                validation_result_identifier=validation_result_identifier,
+                suite_validation_result=suite_validation_result,
+                action_context=action_context
             )
-
-            # Add sample of unexpected values
-            summary_text = validation_text_blocks[0]["text"]["text"]
-            summary_text += "\n-----------------------\n"
-            if not validation_result_suite.success:
-                for result in validation_result_suite.results:
-                    if not result.success:
-                        expectation_info = result["expectation_config"]["meta"]
-                        summary_text += (
-                            f"\n *Table*:"
-                            f" {expectation_info['table_name']} / "
-                            f"*Column*:"
-                            f" {expectation_info['column_name']} /  "
-                            f"*Expectation*:"
-                            f" {expectation_info['expectation_name']}\n"
-                        )
-
-                        results = result.result
-                        summary_text += (
-                            f"\n *Sample unexpected values*: "
-                            f"{results['partial_unexpected_list'][:3]}"
-                            f" / *Unexpected percentage*: "
-                            f""
-                            f""
-                            f"{results['unexpected_percent_total']}\n"
-                        )
-
-                        summary_text += "-----------------------\n"
-
-            validation_text_blocks[0]["text"]["text"] = summary_text
-
             checkpoint_text_blocks.extend(validation_text_blocks)
 
         payload = self.renderer.concatenate_text_blocks(
             action_name=self.name,
             text_blocks=checkpoint_text_blocks,
             success=success,
-            checkpoint_name=checkpoint_name,
+            checkpoint_name=checkpoint_result.checkpoint_config.name,
             run_id=checkpoint_result.run_id,
         )
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -44,8 +44,8 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                     results = result.result
                     summary_text += (
                         f"""
-                        \n *Column*: {expectation_info['column_name']}\n 
-*Expectation*: {expectation_info['expectation_name']}\n
+\n *Column*: `{expectation_info['column_name']}`, *Expectation*: `{expectation_info['expectation_name']}`\n
+:information_source: Additional information
 *Sample unexpected values*:  {results['partial_unexpected_list'][:3]}\n
 *Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
 -----------------------\n
@@ -53,7 +53,6 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                     )
 
         validation_text_blocks[0]["text"]["text"] = summary_text
-        validation_text_blocks[0]["text"]["type"] = "mrkdwn"
 
         # summary_text += "-----------------------\n"
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -112,15 +112,15 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                     if not result.success:
                         print(result)
                         expectation_info = result['expectation_config']['meta']
-                        summary_text += (f"*Table*:"
+                        summary_text += (f"\n *Table*:"
                                          f" {expectation_info['table_name']} / "
                                          f"*Column*:"
                                          f" {expectation_info['column_name']} /  "
                                          f"*Expectation*:"
-                                         f" {expectation_info['expectation_name']}\\n")
+                                         f" {expectation_info['expectation_name']}\n")
 
                         results = result.result
-                        summary_text += (f"*Sample unexpected values*: "
+                        summary_text += (f"\n *Sample unexpected values*: "
                                          f"{results['partial_unexpected_list'][:3]}"
                                          f" / *Unexpected percentage*: "
                                          f"{results['unexpected_percent_total']}"

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -107,6 +107,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
 
             # Add sample of unexpected values
             summary_text = validation_text_blocks[0]["text"]["text"]
+            summary_text += "\n-----------------------\n"
             if not validation_result_suite.success:
                 for result in validation_result_suite.results:
                     if not result.success:
@@ -127,6 +128,8 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                                          f""
                                          f"{results['unexpected_percent_total']}\n"
                                          )
+
+                        summary_text += "-----------------------\n"
 
             validation_text_blocks[0]["text"]["text"] = summary_text
             print(validation_text_blocks)

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -44,7 +44,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                     summary_text += (
                         f"""
                         \n *Column*: {expectation_info['column_name']}\n 
-                        *Expectation*: {expectation_info['expectation_name']}\n
+*Expectation*: {expectation_info['expectation_name']}\n
                         """
                     )
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -11,8 +11,6 @@ from great_expectations.data_context.types.resource_identifiers import (
     ValidationResultIdentifier,
 )
 
-# https://medium.com/@jojo-data/how-to-create-a-custom-module-in-great-expectations-efd0a6ed704a
-
 
 class CustomSlackNotificationAction(SlackNotificationAction):
     @staticmethod

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -47,7 +47,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
 :information_source: Details:
 *Sample unexpected values*:  ```{results['partial_unexpected_list'][:3]}```\n
 *Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
-*Expectation parameters*: `{parameters}`\n
+*Expectation parameters*: ```{parameters}```\n
 -----------------------\n
             """
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -1,0 +1,116 @@
+from typing import Literal, override
+
+from great_expectations.checkpoint.actions import ActionContext, _should_notify
+from great_expectations.checkpoint.checkpoint import CheckpointResult
+from great_expectations.core import ExpectationSuiteValidationResult
+from great_expectations.render.renderer.slack_renderer import SlackRenderer
+# https://medium.com/@jojo-data/how-to-create-a-custom-module-in-great-expectations-efd0a6ed704a
+
+from great_expectations.compatibility.pydantic import Field
+
+
+from great_expectations.checkpoint import SlackNotificationAction
+
+
+class CustomSlackRenderer(SlackRenderer):
+    def _build_description_block(
+            self,
+            validation_result: ExpectationSuiteValidationResult,
+            validation_result_urls: list[str],
+    ) -> dict:
+        status = "Failed :x:"
+        if validation_result.success:
+            status = "Success :tada:"
+
+        validation_link = None
+        summary_text = ""
+        if validation_result_urls:
+            if len(validation_result_urls) == 1:
+                validation_link = validation_result_urls[0]
+            else:
+                title_hlink = "*Validation Results*"
+                batch_validation_status_hlinks = "".join(
+                    f"*<{validation_result_url} | {status}>*"
+                    for validation_result_url in validation_result_urls
+                )
+                summary_text += f"""{title_hlink}
+    {batch_validation_status_hlinks}
+                """
+
+        expectation_suite_name = validation_result.suite_name
+        data_asset_name = validation_result.asset_name or "__no_data_asset_name__"
+        summary_text += f"*Asset*: {data_asset_name}\\n"
+        # Slack does not allow links to local files due to security risks
+        # DataDocs links will be added in a block after this summary text when applicable
+        if validation_link and "file://" not in validation_link:
+            summary_text += (
+                f"*Expectation Suite*: {expectation_suite_name}  <{validation_link}|View Results>"
+            )
+        else:
+            summary_text += f"*Expectation Suite*: {expectation_suite_name}\\n"
+
+        # Add sample of unexpected values
+        if not validation_result.success:
+            for result in validation_result.results:
+                if not result.success:
+                    expectation_info = result.expectation_config.meta
+                    summary_text += (f"*Table*:"
+                                     f" {expectation_info['table_name']} / "
+                                     f"*Column*:"
+                                     f" {expectation_info['column_name']} /  "
+                                     f"*Expectation*:"
+                                     f" {expectation_info['expectation_name']}\\n")
+
+                    results = result.result
+                    summary_text += (f"*Sample unexpected values*: "
+                                     f"{results['partial_unexpected_list'][:3]}"
+                                     f" / *Unexpected percentage*: "
+                                     f"{results['unexpected_percent_total']}"
+                                     )
+
+        return {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": summary_text,
+            },
+        }
+
+
+class CustomSlackNotificationAction(SlackNotificationAction):
+    type: Literal["custom_slack"] = "custom_slack"
+    renderer: CustomSlackRenderer = Field(default_factory=CustomSlackRenderer)
+
+    @override
+    def run(
+            self, checkpoint_result: CheckpointResult,
+            action_context: ActionContext | None = None
+    ) -> dict:
+        success = checkpoint_result.success or False
+        checkpoint_name = checkpoint_result.checkpoint_config.name
+        result = {"slack_notification_result": "none required"}
+
+        if not _should_notify(success=success, notify_on=self.notify_on):
+            return result
+
+        checkpoint_text_blocks: list[dict] = []
+        for (
+                validation_result_suite_identifier,
+                validation_result_suite,
+        ) in checkpoint_result.run_results.items():
+            validation_text_blocks = self._render_validation_result(
+                result_identifier=validation_result_suite_identifier,
+                result=validation_result_suite,
+                action_context=action_context,
+            )
+            checkpoint_text_blocks.extend(validation_text_blocks)
+
+        payload = self.renderer.concatenate_text_blocks(
+            action_name=self.name,
+            text_blocks=checkpoint_text_blocks,
+            success=success,
+            checkpoint_name=checkpoint_name,
+            run_id=checkpoint_result.run_id,
+        )
+
+        return self._send_slack_notification(payload=payload)

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -78,7 +78,7 @@ class CustomSlackRenderer(SlackRenderer):
 
 
 class CustomSlackNotificationAction(SlackNotificationAction):
-    type: Literal["custom_slack"] = "custom_slack"
+    # type: Literal["custom_slack"] = "custom_slack"
     # renderer: CustomSlackRenderer = Field(default_factory=CustomSlackRenderer)
 
     # @override

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -1,22 +1,16 @@
-from typing import Literal
-
+from great_expectations.checkpoint import SlackNotificationAction
 from great_expectations.checkpoint.actions import ActionContext, _should_notify
 from great_expectations.checkpoint.checkpoint import CheckpointResult
-from great_expectations.core import ExpectationSuiteValidationResult
-from great_expectations.render.renderer.slack_renderer import SlackRenderer
+
 # https://medium.com/@jojo-data/how-to-create-a-custom-module-in-great-expectations-efd0a6ed704a
-
-from great_expectations.compatibility.pydantic import Field
-
-
-from great_expectations.checkpoint import SlackNotificationAction
 
 
 class CustomSlackNotificationAction(SlackNotificationAction):
     # @override
     def run(
-            self, checkpoint_result: CheckpointResult,
-            action_context: ActionContext | None = None
+        self,
+        checkpoint_result: CheckpointResult,
+        action_context: ActionContext | None = None,
     ) -> dict:
         success = checkpoint_result.success or False
         checkpoint_name = checkpoint_result.checkpoint_config.name
@@ -27,8 +21,8 @@ class CustomSlackNotificationAction(SlackNotificationAction):
 
         checkpoint_text_blocks: list[dict] = []
         for (
-                validation_result_suite_identifier,
-                validation_result_suite,
+            validation_result_suite_identifier,
+            validation_result_suite,
         ) in checkpoint_result.run_results.items():
             validation_text_blocks = self._render_validation_result(
                 result_identifier=validation_result_suite_identifier,
@@ -42,22 +36,25 @@ class CustomSlackNotificationAction(SlackNotificationAction):
             if not validation_result_suite.success:
                 for result in validation_result_suite.results:
                     if not result.success:
-                        expectation_info = result['expectation_config']['meta']
-                        summary_text += (f"\n *Table*:"
-                                         f" {expectation_info['table_name']} / "
-                                         f"*Column*:"
-                                         f" {expectation_info['column_name']} /  "
-                                         f"*Expectation*:"
-                                         f" {expectation_info['expectation_name']}\n")
+                        expectation_info = result["expectation_config"]["meta"]
+                        summary_text += (
+                            f"\n *Table*:"
+                            f" {expectation_info['table_name']} / "
+                            f"*Column*:"
+                            f" {expectation_info['column_name']} /  "
+                            f"*Expectation*:"
+                            f" {expectation_info['expectation_name']}\n"
+                        )
 
                         results = result.result
-                        summary_text += (f"\n *Sample unexpected values*: "
-                                         f"{results['partial_unexpected_list'][:3]}"
-                                         f" / *Unexpected percentage*: "
-                                         f""
-                                         f""
-                                         f"{results['unexpected_percent_total']}\n"
-                                         )
+                        summary_text += (
+                            f"\n *Sample unexpected values*: "
+                            f"{results['partial_unexpected_list'][:3]}"
+                            f" / *Unexpected percentage*: "
+                            f""
+                            f""
+                            f"{results['unexpected_percent_total']}\n"
+                        )
 
                         summary_text += "-----------------------\n"
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -123,7 +123,9 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                         summary_text += (f"\n *Sample unexpected values*: "
                                          f"{results['partial_unexpected_list'][:3]}"
                                          f" / *Unexpected percentage*: "
-                                         f"{results['unexpected_percent_total']}"
+                                         f""
+                                         f""
+                                         f"{results['unexpected_percent_total']}\n"
                                          )
 
             validation_text_blocks[0]["text"]["text"] = summary_text

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -25,7 +25,8 @@ from great_expectations.expectations import core as gx_core
 from pyspark.sql import DataFrame, SparkSession
 
 from .common import Rule, RulesDict, ValidationSettings
-from .custom_renderers.slack_renderer import CustomSlackNotificationAction
+from .custom_renderers.slack_renderer import CustomSlackNotificationAction, \
+    CustomSlackRenderer
 from .output_transformations import (
     write_non_validation_tables,
     write_validation_table,
@@ -209,12 +210,13 @@ class ValidationRunner:
                 name="send_slack_notification",
                 slack_webhook=self.slack_webhook,
                 notify_on=self.notify_on,
-                renderer={
-                    "module_name": "dq_suite.custom_renderers.slack_renderer",
-                    "class_name": "CustomSlackRenderer",
-                    # "module_name": "great_expectations.render.renderer.slack_renderer",
-                    # "class_name": "SlackRenderer",
-                },
+                renderer=CustomSlackRenderer
+                # #{
+                #     "module_name": "dq_suite.custom_renderers.slack_renderer",
+                #     "class_name": "CustomSlackRenderer",
+                #     # "module_name": "great_expectations.render.renderer.slack_renderer",
+                #     # "class_name": "SlackRenderer",
+                # },
             )
         )
 

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import Dict, List, Literal, Tuple
 
 from great_expectations import (

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -304,6 +304,7 @@ def run_validation(
     catalog_name: str,
     table_name: str,
     validation_name: str = "my_validation_name",
+    batch_name: str | None = None,
     data_context_root_dir: str = "/dbfs/great_expectations/",
     slack_webhook: str | None = None,
     ms_teams_webhook: str | None = None,
@@ -323,6 +324,7 @@ def run_validation(
     catalog_name: name of unity catalog
     table_name: name of table in unity catalog
     validation_name: name of data quality check
+    batch_name: name of the batch to validate
     data_context_root_dir: path to write GX data
     context - default "/dbfs/great_expectations/"
     slack_webhook: webhook, recommended to store in key vault. If not None,
@@ -365,6 +367,7 @@ def run_validation(
         dataset_name=dataset_name,
         table_name=table_name,
         validation_name=validation_name,
+        batch_name=batch_name,
         data_context_root_dir=data_context_root_dir,
         slack_webhook=slack_webhook,
         ms_teams_webhook=ms_teams_webhook,

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Literal, Tuple
+from typing import Dict, List, Literal, Tuple, Any
 
 from great_expectations import (
     Checkpoint,
@@ -129,7 +129,8 @@ class ValidationRunner:
         return suite
 
     @staticmethod
-    def _get_gx_expectation_object(validation_rule: Rule, table_name: str):
+    def _get_gx_expectation_object(validation_rule: Rule, table_name: str) ->\
+            Any:
         """
         From great_expectations.expectations.core, get the relevant class and
         instantiate an expectation object with the user-defined parameters

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -210,7 +210,7 @@ class ValidationRunner:
                 slack_webhook=self.slack_webhook,
                 notify_on=self.notify_on,
                 renderer={
-                    "module_name": ".custom_renderers.slack_renderer",
+                    "module_name": "dq_suite.custom_renderers.slack_renderer",
                     "class_name": "CustomSlackRenderer",
                     # "module_name": "great_expectations.render.renderer.slack_renderer",
                     # "class_name": "SlackRenderer",

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -203,14 +203,14 @@ class ValidationRunner:
     ):
         self.action_list.append(
             CustomSlackNotificationAction(
-                name=self.validation_name,  # "send_slack_notification",
+                name="validation",  # TODO: change when using custom renderer
                 slack_webhook=self.slack_webhook,
                 notify_on=self.notify_on,
                 renderer={
                     "module_name": "great_expectations.render.renderer.slack_renderer",
                     "class_name": "SlackRenderer",
                 },
-                # show_failed_expectations=True,  # Doesn't do anything
+                # show_failed_expectations=True,  # Doesn't do anything?
             )
         )
 

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -7,10 +7,7 @@ from great_expectations import (
     ValidationDefinition,
     get_context,
 )
-from great_expectations.checkpoint import (
-    MicrosoftTeamsNotificationAction,
-    SlackNotificationAction,
-)
+from great_expectations.checkpoint import MicrosoftTeamsNotificationAction
 from great_expectations.checkpoint.checkpoint import CheckpointResult
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.data_context import AbstractDataContext
@@ -206,12 +203,10 @@ class ValidationRunner:
     ):
         self.action_list.append(
             CustomSlackNotificationAction(
-                name=self.validation_name, #"send_slack_notification",
+                name=self.validation_name,  # "send_slack_notification",
                 slack_webhook=self.slack_webhook,
                 notify_on=self.notify_on,
                 renderer={
-                    # "module_name": "dq_suite.custom_renderers.slack_renderer",
-                    # "class_name": "CustomSlackRenderer",
                     "module_name": "great_expectations.render.renderer.slack_renderer",
                     "class_name": "SlackRenderer",
                 },

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -25,8 +25,7 @@ from great_expectations.expectations import core as gx_core
 from pyspark.sql import DataFrame, SparkSession
 
 from .common import Rule, RulesDict, ValidationSettings
-from .custom_renderers.slack_renderer import CustomSlackNotificationAction, \
-    CustomSlackRenderer
+from .custom_renderers.slack_renderer import CustomSlackNotificationAction
 from .output_transformations import (
     write_non_validation_tables,
     write_validation_table,

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -210,13 +210,13 @@ class ValidationRunner:
                 name="send_slack_notification",
                 slack_webhook=self.slack_webhook,
                 notify_on=self.notify_on,
-                renderer=CustomSlackRenderer
-                # #{
-                #     "module_name": "dq_suite.custom_renderers.slack_renderer",
-                #     "class_name": "CustomSlackRenderer",
-                #     # "module_name": "great_expectations.render.renderer.slack_renderer",
-                #     # "class_name": "SlackRenderer",
-                # },
+                renderer={
+                    # "module_name": "dq_suite.custom_renderers.slack_renderer",
+                    # "class_name": "CustomSlackRenderer",
+                    "module_name": "great_expectations.render.renderer.slack_renderer",
+                    "class_name": "SlackRenderer",
+                },
+                show_failed_expectations=True,
             )
         )
 

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -207,7 +207,7 @@ class ValidationRunner:
     ):
         self.action_list.append(
             CustomSlackNotificationAction(
-                name="send_slack_notification",
+                name=self.validation_name, #"send_slack_notification",
                 slack_webhook=self.slack_webhook,
                 notify_on=self.notify_on,
                 renderer={

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Literal, Tuple, Any
+from typing import Any, Dict, List, Literal, Tuple
 
 from great_expectations import (
     Checkpoint,
@@ -129,8 +129,9 @@ class ValidationRunner:
         return suite
 
     @staticmethod
-    def _get_gx_expectation_object(validation_rule: Rule, table_name: str) ->\
-            Any:
+    def _get_gx_expectation_object(
+        validation_rule: Rule, table_name: str
+    ) -> Any:
         """
         From great_expectations.expectations.core, get the relevant class and
         instantiate an expectation object with the user-defined parameters

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -346,6 +346,9 @@ def run_validation(
         validation_dict=validation_dict,
         table_name=table_name,
     )
+    dataset_layer = validation_dict["dataset"]["layer"]
+    dataset_name = validation_dict["dataset"]["name"]
+
     if rules_dict is None:
         raise ValueError(
             f"No validations found for table_name "

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -216,7 +216,7 @@ class ValidationRunner:
                     "module_name": "great_expectations.render.renderer.slack_renderer",
                     "class_name": "SlackRenderer",
                 },
-                show_failed_expectations=True,
+                # show_failed_expectations=True,  # Doesn't do anything
             )
         )
 

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -25,6 +25,7 @@ from great_expectations.expectations import core as gx_core
 from pyspark.sql import DataFrame, SparkSession
 
 from .common import Rule, RulesDict, ValidationSettings
+from .custom_renderers.slack_renderer import CustomSlackNotificationAction
 from .output_transformations import (
     write_non_validation_tables,
     write_validation_table,
@@ -204,13 +205,15 @@ class ValidationRunner:
         self,
     ):
         self.action_list.append(
-            SlackNotificationAction(
+            CustomSlackNotificationAction(
                 name="send_slack_notification",
                 slack_webhook=self.slack_webhook,
                 notify_on=self.notify_on,
                 renderer={
-                    "module_name": "great_expectations.render.renderer.slack_renderer",
-                    "class_name": "SlackRenderer",
+                    "module_name": ".custom_renderers.slack_renderer",
+                    "class_name": "CustomSlackRenderer",
+                    # "module_name": "great_expectations.render.renderer.slack_renderer",
+                    # "class_name": "SlackRenderer",
                 },
             )
         )

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -377,9 +377,8 @@ def run_validation(
     # 3) ... and write results to unity catalog
     if write_results_to_unity_catalog:
         validation_output = checkpoint_result.describe_dict()
-        run_time = (
-            datetime.datetime.now()
-        )  # TODO: get from RunIdentifier object
+        run_time = checkpoint_result.run_id.run_time
+
         write_non_validation_tables(
             dq_rules_dict=validation_dict,
             validation_settings_obj=validation_settings_obj,

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -80,6 +80,7 @@ class ValidationRunner:
             validation_settings_obj.data_context_root_dir
         )
         self.data_source_name = validation_settings_obj._data_source_name
+        self.data_asset_name = validation_settings_obj._data_asset_name
         self.expectation_suite_name = (
             validation_settings_obj._expectation_suite_name
         )
@@ -161,7 +162,7 @@ class ValidationRunner:
             name=self.data_source_name
         )
         self.dataframe_asset = self.data_source.add_dataframe_asset(
-            name=self.validation_name
+            name=self.data_asset_name
         )
 
         self.batch_definition = (

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -215,6 +215,8 @@ class TestValidationSettings:
         catalog_name="the_catalog",
         table_name="the_table",
         validation_name="the_validation",
+        dataset_layer="the_layer",
+        dataset_name="the_name",
     )
 
     def test_initialisation_with_wrong_typed_spark_session_raises_type_error(
@@ -226,6 +228,8 @@ class TestValidationSettings:
                 catalog_name="the_catalog",
                 table_name="the_table",
                 validation_name="the_validation",
+                dataset_layer="the_layer",
+                dataset_name="the_name",
             )
 
     def test_initialisation_with_wrong_typed_catalog_name_raises_type_error(
@@ -237,6 +241,8 @@ class TestValidationSettings:
                 catalog_name=123,
                 table_name="the_table",
                 validation_name="the_validation",
+                dataset_layer="the_layer",
+                dataset_name="the_name",
             )
 
     def test_initialisation_with_wrong_typed_table_name_raises_type_error(self):
@@ -246,6 +252,8 @@ class TestValidationSettings:
                 catalog_name="the_catalog",
                 table_name=123,
                 validation_name="the_validation",
+                dataset_layer="the_layer",
+                dataset_name="the_name",
             )
 
     def test_initialisation_with_wrong_typed_validation_name_raises_type_error(
@@ -257,6 +265,8 @@ class TestValidationSettings:
                 catalog_name="the_catalog",
                 table_name="the_table",
                 validation_name=123,
+                dataset_layer="the_layer",
+                dataset_name="the_name",
             )
 
     def test_initialisation_with_wrong_typed_data_context_root_dir_raises_type_error(
@@ -268,6 +278,8 @@ class TestValidationSettings:
                 catalog_name="the_catalog",
                 table_name="the_table",
                 validation_name="the_validation_name",
+                dataset_layer="the_layer",
+                dataset_name="the_name",
                 data_context_root_dir=123,
             )
 
@@ -280,6 +292,8 @@ class TestValidationSettings:
                 catalog_name="the_catalog",
                 table_name="the_table",
                 validation_name="the_validation_name",
+                dataset_layer="the_layer",
+                dataset_name="the_name",
                 slack_webhook=123,
             )
 
@@ -292,6 +306,8 @@ class TestValidationSettings:
                 catalog_name="the_catalog",
                 table_name="the_table",
                 validation_name="the_validation_name",
+                dataset_layer="the_layer",
+                dataset_name="the_name",
                 ms_teams_webhook=123,
             )
 
@@ -304,6 +320,8 @@ class TestValidationSettings:
                 catalog_name="the_catalog",
                 table_name="the_table",
                 validation_name="the_validation_name",
+                dataset_layer="the_layer",
+                dataset_name="the_name",
                 notify_on="haha_this_is_wrong",
             )
 
@@ -322,7 +340,7 @@ class TestValidationSettings:
         self.validation_settings_obj._set_checkpoint_name()
         assert (
             self.validation_settings_obj._checkpoint_name
-            == f"{self.validation_settings_obj.validation_name}_checkpoint"
+            == f"{self.validation_settings_obj.dataset_layer}/{self.validation_settings_obj.dataset_name}/{self.validation_settings_obj.table_name}"
         )
 
     def test_set_run_name(self):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -269,6 +269,46 @@ class TestValidationSettings:
                 dataset_name="the_name",
             )
 
+    def test_initialisation_with_wrong_typed_dataset_layer_raises_type_error(
+        self,
+    ):
+        with pytest.raises(TypeError):
+            assert ValidationSettings(
+                spark_session=self.spark_session_mock,
+                catalog_name="the_catalog",
+                table_name="the_table",
+                validation_name="the_validation",
+                dataset_layer=123,
+                dataset_name="the_name",
+            )
+
+    def test_initialisation_with_wrong_typed_dataset_name_raises_type_error(
+        self,
+    ):
+        with pytest.raises(TypeError):
+            assert ValidationSettings(
+                spark_session=self.spark_session_mock,
+                catalog_name="the_catalog",
+                table_name="the_table",
+                validation_name="the_validation",
+                dataset_layer="the_layer",
+                dataset_name=123,
+            )
+
+    def test_initialisation_with_wrong_typed_batch_name_raises_type_error(
+        self,
+    ):
+        with pytest.raises(TypeError):
+            assert ValidationSettings(
+                spark_session=self.spark_session_mock,
+                catalog_name="the_catalog",
+                table_name="the_table",
+                validation_name="the_validation",
+                dataset_layer="the_layer",
+                dataset_name="the_name",
+                batch_name=123,
+            )
+
     def test_initialisation_with_wrong_typed_data_context_root_dir_raises_type_error(
         self,
     ):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -20,6 +20,8 @@ def validation_settings_obj():
         catalog_name="the_catalog",
         table_name="the_table",
         validation_name="the_validation",
+        dataset_layer="the_layer",
+        dataset_name="the_name",
     )
     return validation_settings_obj
 


### PR DESCRIPTION
This PR uses the existing `SlackNotificationAction` class for modifying the Slack message output, as per https://docs.greatexpectations.io/docs/core/trigger_actions_based_on_results/create_a_custom_action/

Added: 
- the name of the failing expectation(s)
- parameter values used for the expectation
- the column name the expectation was applied to
- sample of unexpected records
- count of unexpected number of rows

Out of scope: 
- A future PR should address issues due to the default Slack renderer, see `great_expectations.render.renderer.slack_renderer`, including the default header of the Slack message. 
  - An attempt at quickly modifying this renderer resulted in some GX-internal checks on the custom renderer failing, so this was dropped for the current PR. 
- A future PR should also include path(s) to the faulty data on the landing zone in the Slack message. This would require the Spark dataframe to include an `input_file_name` column using the `input_file_name`  function from `pyspark.sql.functions`. 