### PR TITLE
Fix/slack output set type expectations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dq-suite-amsterdam"
-version = "0.11.14"
+version = "0.11.15"
 authors = [
   { name="Arthur Kordes", email="a.kordes@amsterdam.nl" },
   { name="Aysegul Cayir Aydar", email="a.cayiraydar@amsterdam.nl" },

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -49,13 +49,14 @@ class CustomSlackNotificationAction(SlackNotificationAction):
         # Output for Set-type expectations is differently structured
         # TODO: refactor this output more neatly into a function
         if expectation_metadata['expectation_name'] == "ExpectTableColumnsToMatchSet":
+            column_set = result["expectation_config"]["kwargs"]["column_set"]
             return f"""
-                \n *Expectation*: `{expectation_metadata['expectation_name']}`\n\n
-                :information_source: Details:
-                *Unexpected columns*:  ```{results["details"]["mismatched"]["unexpected"]}```\n
-                *Missing columns*:  ```{results["details"]["mismatched"]["missing"]}```\n
-                *Expected columns*: ```{results["expectation_config"]["column_set"]}```\n
-                -----------------------\n
+    \n *Expectation*: `{expectation_metadata['expectation_name']}`\n\n
+    :information_source: Details:
+    *Unexpected columns*:  ```{results["details"]["mismatched"]["unexpected"]}```\n
+    *Missing columns*:  ```{results["details"]["mismatched"]["missing"]}```\n
+    *Expected columns*: ```{column_set}```\n
+    -----------------------\n
                 """
         else:
             parameters = self._get_expectation_parameters_dict(result=result)

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -44,14 +44,15 @@ class CustomSlackNotificationAction(SlackNotificationAction):
         self, result: ExpectationValidationResult
     ) -> str:
         expectation_metadata = result["expectation_config"]["meta"]
+        expectation_name = expectation_metadata["expectation_name"]
         results = result.result
 
         # Output for Set-type expectations is differently structured
         # TODO: refactor this output more neatly into a function
-        if expectation_metadata['expectation_name'] == "ExpectTableColumnsToMatchSet":
+        if expectation_name == "ExpectTableColumnsToMatchSet":
             column_set = result["expectation_config"]["kwargs"]["column_set"]
             return f"""
-    \n *Expectation*: `{expectation_metadata['expectation_name']}`\n\n
+    \n *Expectation*: `{expectation_name}`\n\n
     :information_source: Details:
     *Unexpected columns*:  ```{results["details"]["mismatched"]["unexpected"]}```\n
     *Missing columns*:  ```{results["details"]["mismatched"]["missing"]}```\n
@@ -61,7 +62,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
         else:
             parameters = self._get_expectation_parameters_dict(result=result)
             return f"""
-    \n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_metadata['expectation_name']}`\n\n
+    \n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_name}`\n\n
     :information_source: Details:
     *Sample unexpected values*:  ```{results['partial_unexpected_list'][:3]}```\n
     *Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -44,17 +44,29 @@ class CustomSlackNotificationAction(SlackNotificationAction):
         self, result: ExpectationValidationResult
     ) -> str:
         expectation_metadata = result["expectation_config"]["meta"]
-        parameters = self._get_expectation_parameters_dict(result=result)
         results = result.result
 
-        return f"""
-\n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_metadata['expectation_name']}`\n\n
-:information_source: Details:
-*Sample unexpected values*:  ```{results['partial_unexpected_list'][:3]}```\n
-*Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
-*Expectation parameters*: ```{parameters}```\n
------------------------\n
-            """
+        # Output for Set-type expectations is differently structured
+        # TODO: refactor this output more neatly into a function
+        if expectation_metadata['expectation_name'] == "ExpectTableColumnsToMatchSet":
+            return f"""
+                \n *Expectation*: `{expectation_metadata['expectation_name']}`\n\n
+                :information_source: Details:
+                *Unexpected columns*:  ```{results["details"]["mismatched"]["unexpected"]}```\n
+                *Missing columns*:  ```{results["details"]["mismatched"]["missing"]}```\n
+                *Expected columns*: ```{results["expectation_config"]["column_set"]}```\n
+                -----------------------\n
+                """
+        else:
+            parameters = self._get_expectation_parameters_dict(result=result)
+            return f"""
+    \n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_metadata['expectation_name']}`\n\n
+    :information_source: Details:
+    *Sample unexpected values*:  ```{results['partial_unexpected_list'][:3]}```\n
+    *Unexpected / total count*: {results['unexpected_count']} / {results['element_count']}\n
+    *Expectation parameters*: ```{parameters}```\n
+    -----------------------\n
+                """
 
     def _get_validation_text_blocks(
         self,

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -140,7 +140,9 @@ class ValidationRunner:
         gx_expectation_name = validation_rule["rule_name"]
         gx_expectation_class = getattr(gx_core, gx_expectation_name)
 
-        gx_expectation_parameters: dict = copy.deepcopy(validation_rule["parameters"])
+        gx_expectation_parameters: dict = copy.deepcopy(
+            validation_rule["parameters"]
+        )
         column_name = gx_expectation_parameters.get("column", None)
 
         gx_expectation_parameters["meta"] = {


### PR DESCRIPTION
The existing solution uses 

```python
partial_unexpected_list[0:3]
```

to provide some samples of unexpected data. This results in a crash for the `ExpectTableColumnsToMatchSet` expectation, since that `partial_unexpected_list` is empty when this expectation fails. 

The current (quick)fix addresses only the issue with this particular expectation, but it eventually should be solved more generally - there are likely more Set/Column-type expectations that would fail in a similar way, hence the `TODO`. This requires a more thorough investigation though. 