### PR TITLE
Fix/slack output missing columns set expectation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [0.11.18] - 14-05-2025
+
+### Added
+
+### Changed
+
+### Fixed
+- Fix for Slack messages resulting from `ExpectTableColumnsToMatchSet` expectations
+
+
+## [0.11.17] - 30-04-2025
+
+### Added
+
+### Changed
+
+### Fixed
+- Allow for Slack messages resulting from validations of empty source files
+
+
 ## [0.11.16] - 30-04-2025
  
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dq-suite-amsterdam"
-version = "0.11.17"
+version = "0.11.18"
 authors = [
   { name="Arthur Kordes", email="a.kordes@amsterdam.nl" },
   { name="Aysegul Cayir Aydar", email="a.cayiraydar@amsterdam.nl" },

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -53,11 +53,13 @@ class CustomSlackNotificationAction(SlackNotificationAction):
             column_set = result["expectation_config"]["kwargs"]["column_set"]
             unexpected_values = results["details"]["mismatched"].get(
                 "unexpected", None)  # Could be an empty collection/absent
+            missing_values = results["details"]["mismatched"].get(
+                "missing", None)  # Could be an empty collection/absent
             return f"""
     \n *Expectation*: `{expectation_name}`\n\n
     :information_source: Details:
     *Unexpected columns*:  ```{unexpected_values}```\n
-    *Missing columns*:  ```{results["details"]["mismatched"]["missing"]}```\n
+    *Missing columns*:  ```{missing_values}```\n
     *Expected columns*: ```{column_set}```\n
     -----------------------\n
                 """

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -52,9 +52,11 @@ class CustomSlackNotificationAction(SlackNotificationAction):
         if expectation_name == "ExpectTableColumnsToMatchSet":
             column_set = result["expectation_config"]["kwargs"]["column_set"]
             unexpected_values = results["details"]["mismatched"].get(
-                "unexpected", None)  # Could be an empty collection/absent
+                "unexpected", None
+            )  # Could be an empty collection/absent
             missing_values = results["details"]["mismatched"].get(
-                "missing", None)  # Could be an empty collection/absent
+                "missing", None
+            )  # Could be an empty collection/absent
             return f"""
     \n *Expectation*: `{expectation_name}`\n\n
     :information_source: Details:
@@ -65,8 +67,9 @@ class CustomSlackNotificationAction(SlackNotificationAction):
                 """
         else:
             parameters = self._get_expectation_parameters_dict(result=result)
-            partial_unexpected_list = results.get("partial_unexpected_list",
-                                                  None)
+            partial_unexpected_list = results.get(
+                "partial_unexpected_list", None
+            )
             if partial_unexpected_list is not None:
                 partial_unexpected_list = partial_unexpected_list[:3]
             return f"""


### PR DESCRIPTION
Simple fix: in the absence of 'missing' columns for a `ExpectTableColumnsToMatchSet` expectation, the DQ suite shouldn't crash due to a KeyError for the 'missing' key of the results dictionary. 