### PR TITLE
Add description field to data quality rules and enhance Slack notifications (#116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ See the documentation of `dq_suite.validation.run_validation` for what other par
 For further documentation, see:
 - [other functionalities](docs/Readme-other.md)
 - [notes for developers](docs/Readme-dev.md)
-- [description field for business-friendly alerts](docs/description-field.md)
 - [notes for data engineers at Gemeente Amsterdam](https://dev.azure.com/CloudCompetenceCenter/Dataplatform%20en%20Data%20organisatie/_git/vakgroep_data_engineering?path=/docs/03_knowledge_bank/topics/data_quality/data_quality.md&_a=preview) (in Dutch, employees only)
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # About dq-suite-amsterdam
 This repository aims to be an easy-to-use wrapper for the data quality library [Great Expectations](https://github.com/great-expectations/great_expectations) (GX). All that is needed to get started is an in-memory Spark dataframe and a set of data quality rules - specified in a JSON file [of particular formatting](dq_rules_example.json). 
 
-By default, all the validation results are written to Unity Catalog. Alternatively, one could disallow writing to a `data_quality` schema in UC, which one has to create once per catalog via [this notebook](scripts/data_quality_tables.sql). Additionally, users can choose to get notified via Slack or Microsoft Teams.
+By default, all the validation results are written to Unity Catalog. Alternatively, one could disallow writing to a `data_quality` schema in UC, which one has to create once per catalog via [this notebook](scripts/data_quality_tables.sql). Additionally, users can choose to get notified via Slack or Microsoft Teams with business-friendly descriptions for each data quality check.
 
 <img src="docs/wip_computer.jpg" width="20%" height="auto">
 
@@ -51,6 +51,7 @@ See the documentation of `dq_suite.validation.run_validation` for what other par
 For further documentation, see:
 - [other functionalities](docs/Readme-other.md)
 - [notes for developers](docs/Readme-dev.md)
+- [description field for business-friendly alerts](docs/description-field.md)
 - [notes for data engineers at Gemeente Amsterdam](https://dev.azure.com/CloudCompetenceCenter/Dataplatform%20en%20Data%20organisatie/_git/vakgroep_data_engineering?path=/docs/03_knowledge_bank/topics/data_quality/data_quality.md&_a=preview) (in Dutch, employees only)
 
 

--- a/dq_rules_example.json
+++ b/dq_rules_example.json
@@ -10,6 +10,7 @@
             "rules": [
                 {
                     "rule_name": "ExpectColumnValuesToBeBetween",
+                    "description": "Latitude values must be between 6 and 10000",
                     "parameters": {
                             "column": "latitude",
                             "min_value": 6,
@@ -18,6 +19,7 @@
                 },
                 {
                     "rule_name": "ExpectColumnDistinctValuesToEqualSet",
+                    "description": "Latitude column should only contain values 1 or 2",
                     "parameters": {
                             "column": "latitude",
                             "value_set": [1, 2]
@@ -31,6 +33,7 @@
             "rules": [
                 {
                     "rule_name": "ExpectColumnValuesToNotBeNull",
+                    "description": "Checks that the value is always provided",
                     "parameters": {
                             "column": "containertype"
                         }

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Dict, List, Literal
 
 from delta.tables import *
 from pyspark.sql import DataFrame, SparkSession
@@ -18,6 +18,7 @@ class Rule:
     parameters: Dict[str, Any]  # Collection of parameters required for
     # evaluating the expectation
     norm: int | None = None  # TODO/check: what is the meaning of this field? Add documentation.
+    description: str | None = None  # Natural language description for business stakeholders
 
     def __post_init__(self):
         if not isinstance(self.rule_name, str):
@@ -30,6 +31,14 @@ class Rule:
             if self.norm is not None:
                 raise TypeError("'norm' should be of type int")
 
+        if not isinstance(self.description, str):
+            if self.description is not None:
+                raise TypeError("'description' should be of type str")
+        
+        # Limit description to 250 characters for practical alerting purposes
+        if self.description is not None and len(self.description) > 250:
+            raise ValueError("'description' should not exceed 250 characters")
+
     def __getitem__(self, key) -> str | Dict[str, Any] | int | None:
         if key == "rule_name":
             return self.rule_name
@@ -37,6 +46,8 @@ class Rule:
             return self.parameters
         elif key == "norm":
             return self.norm
+        elif key == "description":
+            return self.description
         raise KeyError(key)
 
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -45,7 +45,13 @@ class CustomSlackNotificationAction(SlackNotificationAction):
     ) -> str:
         expectation_metadata = result["expectation_config"]["meta"]
         expectation_name = expectation_metadata["expectation_name"]
+        description = expectation_metadata.get("description", None)
         results = result.result
+
+        # Create description text block if available
+        description_text = ""
+        if description:
+            description_text = f"\n *Check Description*: {description}\n"
 
         # Output for Set-type expectations is differently structured
         # TODO: refactor this output more neatly into a function
@@ -63,6 +69,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
     *Unexpected columns*:  ```{unexpected_values}```\n
     *Missing columns*:  ```{missing_values}```\n
     *Expected columns*: ```{column_set}```\n
+    *Description text*: ```{description}```\n
     -----------------------\n
                 """
         else:
@@ -73,7 +80,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
             if partial_unexpected_list is not None:
                 partial_unexpected_list = partial_unexpected_list[:3]
             return f"""
-    \n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_name}`\n\n
+    \n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_name}`    *Description*:`{description_text}`\n\n
     :information_source: Details:
     *Sample unexpected values*:  ```{partial_unexpected_list}```\n
     *Unexpected / total count*: {results.get('unexpected_count', None)} / {results.get('element_count', 0)}\n

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -144,11 +144,13 @@ class ValidationRunner:
             validation_rule["parameters"]
         )
         column_name = gx_expectation_parameters.get("column", None)
+        description = validation_rule.get("description", None)
 
         gx_expectation_parameters["meta"] = {
             "table_name": table_name,
             "column_name": column_name,
             "expectation_name": gx_expectation_name,
+            "description": description,
         }
         return gx_expectation_class(**gx_expectation_parameters)
 

--- a/src/dq_suite/validation_input.py
+++ b/src/dq_suite/validation_input.py
@@ -146,6 +146,12 @@ def validate_rule(rule: dict) -> None:
     if not isinstance(rule["parameters"], dict):
         raise TypeError(f"In {rule}, 'parameters' should be of type 'dict'")
 
+    # Validate optional 'description' field
+    if "description" in rule:
+        if not isinstance(rule["description"], str):
+            raise TypeError(f"In {rule}, 'description' should be of type 'str'")
+        if len(rule["description"]) > 250:
+            raise ValueError(f"In {rule}, 'description' should not exceed 250 characters (current: {len(rule['description'])})")
 
 def get_data_quality_rules_dict(file_path: str) -> DataQualityRulesDict:
     dq_rules_json_string = read_data_quality_rules_from_json(

--- a/test_description_example.json
+++ b/test_description_example.json
@@ -1,0 +1,38 @@
+{
+    "dataset": {
+        "name": "TestDataset",
+        "layer": "Bronze"
+    },
+    "tables": [
+        {   
+            "unique_identifier": "id",
+            "table_name": "customers",
+            "rules": [
+                {
+                    "rule_name": "ExpectColumnValuesToNotBeNull",
+                    "description": "Customer email must always be provided for communication purposes",
+                    "parameters": {
+                        "column": "email"
+                    }
+                },
+                {
+                    "rule_name": "ExpectColumnValuesToBeBetween",
+                    "description": "Customer age should be within reasonable human lifespan (0-150 years)",
+                    "parameters": {
+                        "column": "age",
+                        "min_value": 0,
+                        "max_value": 150
+                    }
+                },
+                {
+                    "rule_name": "ExpectColumnDistinctValuesToEqualSet",
+                    "description": "Customer status must be one of the predefined valid states",
+                    "parameters": {
+                        "column": "status",
+                        "value_set": ["active", "inactive", "pending"]
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/test_description_integration.py
+++ b/test_description_integration.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+from dq_suite.validation_input import get_data_quality_rules_dict
+
+def test_description_integration():
+    """Test that description fields work in JSON parsing and validation"""
+    
+    print("Testing description field integration...")
+    
+    # Test with example JSON
+    try:
+        dq_rules = get_data_quality_rules_dict('dq_rules_example.json')
+        print("✓ Successfully parsed example JSON with description fields")
+        
+        # Check first rule with description
+        first_table = dq_rules['tables'][0]
+        first_rule = first_table['rules'][0]
+        print(f"First rule: {first_rule['rule_name']}")
+        
+        if 'description' in first_rule:
+            print(f"Description: {first_rule['description']}")
+            print("✓ Description field is present and accessible")
+        else:
+            print("! No description field found in first rule")
+            
+    except Exception as e:
+        print(f"Error with example JSON: {e}")
+        
+    # Test with test data JSON
+    try:
+        test_dq_rules = get_data_quality_rules_dict('tests/test_data/dq_rules.json')
+        print("✓ Successfully parsed test JSON with description fields")
+        
+        # Check first rule with description  
+        test_first_table = test_dq_rules['tables'][0]
+        test_first_rule = test_first_table['rules'][0]
+        print(f"Test rule: {test_first_rule['rule_name']}")
+        
+        if 'description' in test_first_rule:
+            print(f"Test description: {test_first_rule['description']}")
+            print("✓ Test description field is present and accessible")
+        else:
+            print("! No description field found in test rule")
+            
+    except Exception as e:
+        print(f"Error with test JSON: {e}")
+
+if __name__ == "__main__":
+    test_description_integration()

--- a/tests/test_data/dq_rules.json
+++ b/tests/test_data/dq_rules.json
@@ -10,6 +10,7 @@
             "rules": [
                 {
                     "rule_name": "ExpectColumnDistinctValuesToEqualSet",
+                    "description": "The column should only contain values 1, 2, or 3",
                     "parameters": {
                             "column": "the_column",
                             "value_set": [1, 2, 3]

--- a/tests/test_validation_input.py
+++ b/tests/test_validation_input.py
@@ -312,6 +312,31 @@ class TestValidateRule:
         with pytest.raises(TypeError):
             validate_rule(rule={"rule_name": "TheRule", "parameters": 456})
 
+    def test_validate_rule_with_non_string_description_raises_type_error(
+        self,
+    ):
+        with pytest.raises(TypeError, match="'description' should be of type 'str'"):
+            validate_rule(
+                rule={
+                    "rule_name": "TheRule",
+                    "parameters": {"some_key": "some_value"},
+                    "description": 123,
+                }
+            )
+
+    def test_validate_rule_with_long_description_raises_value_error(
+        self,
+    ):
+        long_description = "x" * 251  # Exceeds 250 character limit
+        with pytest.raises(ValueError, match="'description' should not exceed 250 characters"):
+            validate_rule(
+                rule={
+                    "rule_name": "TheRule",
+                    "parameters": {"some_key": "some_value"},
+                    "description": long_description,
+                }
+            )
+
     def test_validate_rule_works_as_expected(
         self,
     ):
@@ -319,6 +344,7 @@ class TestValidateRule:
             rule={
                 "rule_name": "TheRule",
                 "parameters": {"some_key": "some_value"},
+                "description": "This is a business-friendly description",
             }
         )
 


### PR DESCRIPTION
- Introduced a 'description' field in the data quality rules for better clarity.
- Updated Slack notification renderer to include the description in alerts.
- Added validation for the description field in the rules.
- Created integration tests to ensure description fields are parsed correctly.
- Updated example JSON files to demonstrate the use of the description field.

This is my contribution as our volunteer work for the city of Amsterdam celebrating 750 years!