### PR TITLE
Microsoft teams alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.coverage
+htmlcov/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+## [0.14.1] - 04-15-2026
+
+### Added
+- Microsoft team alert functionality added, by passing the webhook and the notify parameters
+
 ## [0.14.0] - 03-27-2026
 
 ### Added

--- a/docs/Readme-other.md
+++ b/docs/Readme-other.md
@@ -43,9 +43,9 @@ For more info on MS Teams webhooks, click [here](https://learn.microsoft.com/en-
 
 *Note*: this notification method is also supported [via Great Expectations](https://docs.greatexpectations.io/docs/reference/api/checkpoint/MicrosoftTeamsNotificationAction_class) by default, new renderer method is added for Microsoft teams alert.
 
-Prerequistries:
-- Create a workflow for webhook on Micrsoft teams chat. click [here](https://learn.microsoft.com/th-th/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook?tabs=dotnet#create-an-incoming-webhook-from-a-template)
-- Add The application firwall in databricks otap.json file. Add the webhook url to firewall for each workspace. The file can found the project https://dev.azure.com/CloudCompetenceCenter/Cloud%20Platform%20Operations
+Prerequisites:
+- Create a workflow for webhook on Microsoft teams chat. click [here](https://learn.microsoft.com/th-th/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook?tabs=dotnet#create-an-incoming-webhook-from-a-template)
+- Add The application firewall in databricks otap.json file to allow webhook url to workspace. The file can found the project https://dev.azure.com/CloudCompetenceCenter/Cloud%20Platform%20Operations
 
 ```json
         {
@@ -64,7 +64,7 @@ mswebhook ="https://default72fca1b12c2e4376a445294d801968.04.environment.api.pow
  
 from dq_suite.validation import run_validation
 run_validation(
-    json_path='/Workspace/Users/r.chellaswamy@amsterdam.nl/rules.json',
+    json_path=<<dq_rule_json_path>>,
     df=dfs[0],
     spark_session=spark,
     catalog_name='dpd1_dev',

--- a/docs/Readme-other.md
+++ b/docs/Readme-other.md
@@ -41,9 +41,37 @@ The current implementation uses a `CustomSlackNotificationAction` for sending no
 The `dq_suite.validation.run_validation` function takes an `ms_teams_webhook` (string-typed) parameter, which is set to `None` by default. Furthermore, the `notify_on` (string-typed) parameter indicates when notifications will be sent: this could be set equal to `"all"`, `"success"` or `"failure"` (default). 
 For more info on MS Teams webhooks, click [here](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook?tabs=newteams%2Cdotnet#create-an-incoming-webhook).
 
-*Note*: this notification method is also supported [via Great Expectations](https://docs.greatexpectations.io/docs/reference/api/checkpoint/MicrosoftTeamsNotificationAction_class) by default, but (as of March '25) needs to be significantly improved to be on par with the contents of the Slack notifications. 
+*Note*: this notification method is also supported [via Great Expectations](https://docs.greatexpectations.io/docs/reference/api/checkpoint/MicrosoftTeamsNotificationAction_class) by default, new renderer method is added for Microsoft teams alert.
 
+Prerequistries:
+- Create a workflow for webhook on Micrsoft teams chat. click [here](https://learn.microsoft.com/th-th/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook?tabs=dotnet#create-an-incoming-webhook-from-a-template)
+- Add The application firwall in databricks otap.json file. Add the webhook url to firewall for each workspace. The file can found the project https://dev.azure.com/CloudCompetenceCenter/Cloud%20Platform%20Operations
 
+`        {
+          "name": "allow-msteams-webhook-api-call",
+          "description": "Allow Databricks to call MS teams webhook.",
+          "source": ["databricks-public"],
+          "destination": ["[WEB]*.environment.api.powerplatform.com"],
+          "protocol": ["https"],
+          "port": [443]
+        } 
+`
+- Use the parameters `ms_teams_webhook` and `notify_on` in run_validation method.
+For example:
+`
+mswebhook ="https://default72fca1b12c2e4376a445294d801968.04.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/417be331......."
+ 
+from dq_suite.validation import run_validation
+run_validation(
+    json_path='/Workspace/Users/r.chellaswamy@amsterdam.nl/rules.json',
+    df=dfs[0],
+    spark_session=spark,
+    catalog_name='dpd1_dev',
+    table_name='well',
+    ms_teams_webhook=mswebhook,
+    notify_on='failure'
+)
+`
 ## Add severity level to the Input Form
 We added a severity level to the `Input Form` to help with prioritizing failed validation rules based on their criticality.
 

--- a/docs/Readme-other.md
+++ b/docs/Readme-other.md
@@ -47,7 +47,8 @@ Prerequistries:
 - Create a workflow for webhook on Micrsoft teams chat. click [here](https://learn.microsoft.com/th-th/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook?tabs=dotnet#create-an-incoming-webhook-from-a-template)
 - Add The application firwall in databricks otap.json file. Add the webhook url to firewall for each workspace. The file can found the project https://dev.azure.com/CloudCompetenceCenter/Cloud%20Platform%20Operations
 
-`        {
+```json
+        {
           "name": "allow-msteams-webhook-api-call",
           "description": "Allow Databricks to call MS teams webhook.",
           "source": ["databricks-public"],
@@ -55,10 +56,10 @@ Prerequistries:
           "protocol": ["https"],
           "port": [443]
         } 
-`
+```
 - Use the parameters `ms_teams_webhook` and `notify_on` in run_validation method.
 For example:
-`
+```python
 mswebhook ="https://default72fca1b12c2e4376a445294d801968.04.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/417be331......."
  
 from dq_suite.validation import run_validation
@@ -71,7 +72,7 @@ run_validation(
     ms_teams_webhook=mswebhook,
     notify_on='failure'
 )
-`
+```
 ## Add severity level to the Input Form
 We added a severity level to the `Input Form` to help with prioritizing failed validation rules based on their criticality.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "dq-suite-amsterdam"
 
-version = "0.14.0"
+version = "0.14.1"
 
 authors = [
   { name="Arthur Kordes", email="a.kordes@amsterdam.nl" },

--- a/scripts/example_notebook.py
+++ b/scripts/example_notebook.py
@@ -50,7 +50,7 @@ df.summary().show()
 # COMMAND ----------
 
 from dq_suite.validation import run_validation
- 
+
 # run the dataframe validation given the rules defined in dq_rule_json_path
 run_validation(
     json_path=dq_rule_json_path,

--- a/src/dq_suite/custom_renderers/teams_renderer.py
+++ b/src/dq_suite/custom_renderers/teams_renderer.py
@@ -1,0 +1,105 @@
+from typing import TYPE_CHECKING
+
+from great_expectations.core import RunIdentifier
+from great_expectations.render.renderer.microsoft_teams_renderer import (
+    MicrosoftTeamsRenderer,
+)
+
+if TYPE_CHECKING:
+    from great_expectations.checkpoint.checkpoint import CheckpointResult
+    from great_expectations.core.expectation_validation_result import (
+        ExpectationSuiteValidationResult,
+    )
+    from great_expectations.data_context.types.resource_identifiers import (
+        ValidationResultIdentifier,
+    )
+
+
+class CustomMSTeamsRenderer(MicrosoftTeamsRenderer):
+    """Custom Teams renderer that sends an Adaptive Card payload."""
+
+    def render(
+        self,
+        checkpoint_result: "CheckpointResult",
+        data_docs_pages: dict["ValidationResultIdentifier", dict[str, str]] | None = None,
+    ) -> dict:
+        checkpoint_blocks: list[list[dict[str, str]]] = []
+        for result_identifier, result in checkpoint_result.run_results.items():
+            validation_blocks = self._render_validation_result(
+                validation_result=result,
+                validation_result_suite_identifier=result_identifier,
+            )
+            checkpoint_blocks.append(validation_blocks)
+
+        data_docs_block = self._render_data_docs_links(data_docs_pages=data_docs_pages)
+        return self._build_payload(
+            checkpoint_result=checkpoint_result,
+            checkpoint_blocks=checkpoint_blocks,
+            data_docs_block=data_docs_block,
+        )
+
+    def _render_validation_result(
+        self,
+        validation_result: "ExpectationSuiteValidationResult",
+        validation_result_suite_identifier: "ValidationResultIdentifier",
+    ) -> list[dict[str, str]]:
+        return [
+            self._render_status(validation_result=validation_result),
+            self._render_asset_name(validation_result=validation_result),
+            self._render_suite_name(validation_result=validation_result),
+            self._render_run_name(
+                validation_result_suite_identifier=validation_result_suite_identifier
+            ),
+            self._render_batch_id(validation_result=validation_result),
+            self._render_summary(validation_result=validation_result),
+        ]
+
+    def _build_payload(
+        self,
+        checkpoint_result: "CheckpointResult",
+        checkpoint_blocks: list[list[dict[str, str]]],
+        data_docs_block: list[dict[str, str]] | None,
+    ) -> dict:
+        checkpoint_name = checkpoint_result.checkpoint_config.name
+        status = "Success !!!" if checkpoint_result.success else "Failure :("
+
+        title_block = {
+            "type": "TextBlock",
+            "size": "Large",
+            "weight": "Bolder",
+            "text": f"Checkpoint Result: {checkpoint_name} ({status})",
+            "wrap": True,
+        }
+
+        body: list[dict] = [
+            title_block,
+            {"type": "TextBlock", "text": "", "separator": True},
+        ]
+
+        for result_block in checkpoint_blocks:
+            for block in result_block:
+                body.append(block)
+            body.append({"type": "TextBlock", "text": "", "separator": True})
+
+        return {
+            "type": "message",
+            "attachments": [
+                {
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "content": {
+                        "$schema": self.MICROSOFT_TEAMS_SCHEMA_URL,
+                        "type": "AdaptiveCard",
+                        "version": "1.4",
+                        "body": body,
+                        "actions": data_docs_block or [],
+                    },
+                }
+            ],
+        }
+
+    def _render_run_name(
+        self, validation_result_suite_identifier: "ValidationResultIdentifier"
+    ) -> dict[str, str]:
+        run_id = validation_result_suite_identifier.run_id
+        run_name = run_id.run_name if isinstance(run_id, RunIdentifier) else run_id
+        return self._render_validation_result_element(key="Run Name", value=run_name)

--- a/src/dq_suite/custom_renderers/teams_renderer.py
+++ b/src/dq_suite/custom_renderers/teams_renderer.py
@@ -21,7 +21,8 @@ class CustomMSTeamsRenderer(MicrosoftTeamsRenderer):
     def render(
         self,
         checkpoint_result: "CheckpointResult",
-        data_docs_pages: dict["ValidationResultIdentifier", dict[str, str]] | None = None,
+        data_docs_pages: dict["ValidationResultIdentifier", dict[str, str]]
+        | None = None,
     ) -> dict:
         checkpoint_blocks: list[list[dict[str, str]]] = []
         for result_identifier, result in checkpoint_result.run_results.items():
@@ -31,7 +32,9 @@ class CustomMSTeamsRenderer(MicrosoftTeamsRenderer):
             )
             checkpoint_blocks.append(validation_blocks)
 
-        data_docs_block = self._render_data_docs_links(data_docs_pages=data_docs_pages)
+        data_docs_block = self._render_data_docs_links(
+            data_docs_pages=data_docs_pages
+        )
         return self._build_payload(
             checkpoint_result=checkpoint_result,
             checkpoint_blocks=checkpoint_blocks,
@@ -101,5 +104,9 @@ class CustomMSTeamsRenderer(MicrosoftTeamsRenderer):
         self, validation_result_suite_identifier: "ValidationResultIdentifier"
     ) -> dict[str, str]:
         run_id = validation_result_suite_identifier.run_id
-        run_name = run_id.run_name if isinstance(run_id, RunIdentifier) else run_id
-        return self._render_validation_result_element(key="Run Name", value=run_name)
+        run_name = (
+            run_id.run_name if isinstance(run_id, RunIdentifier) else run_id
+        )
+        return self._render_validation_result_element(
+            key="Run Name", value=run_name
+        )

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -8,6 +8,7 @@ from great_expectations import (
     get_context,
 )
 from great_expectations.checkpoint import MicrosoftTeamsNotificationAction
+from .custom_renderers.teams_renderer import CustomMSTeamsRenderer
 from great_expectations.checkpoint.checkpoint import CheckpointResult
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.data_context import AbstractDataContext
@@ -260,10 +261,7 @@ class ValidationRunner:
                 name="send_ms_teams_notification",
                 teams_webhook=self.ms_teams_webhook,
                 notify_on=self.notify_on,
-                renderer={
-                    "module_name": "great_expectations.render.renderer.microsoft_teams_renderer",
-                    "class_name": "MicrosoftTeamsRenderer",
-                },
+                renderer=CustomMSTeamsRenderer(),
             )
         )
 

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -9,6 +9,7 @@ from great_expectations import (
     get_context,
 )
 from great_expectations.checkpoint import MicrosoftTeamsNotificationAction
+from .custom_renderers.teams_renderer import CustomMSTeamsRenderer
 from great_expectations.checkpoint.checkpoint import CheckpointResult
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.data_context import AbstractDataContext
@@ -271,10 +272,7 @@ class ValidationRunner:
                 name="send_ms_teams_notification",
                 teams_webhook=self.ms_teams_webhook,
                 notify_on=self.notify_on,
-                renderer={
-                    "module_name": "great_expectations.render.renderer.microsoft_teams_renderer",
-                    "class_name": "MicrosoftTeamsRenderer",
-                },
+                renderer=CustomMSTeamsRenderer(),
             )
         )
 

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -9,7 +9,6 @@ from great_expectations import (
     get_context,
 )
 from great_expectations.checkpoint import MicrosoftTeamsNotificationAction
-from .custom_renderers.teams_renderer import CustomMSTeamsRenderer
 from great_expectations.checkpoint.checkpoint import CheckpointResult
 from great_expectations.core.batch_definition import BatchDefinition
 from great_expectations.data_context import AbstractDataContext
@@ -26,6 +25,7 @@ from pyspark.sql import DataFrame, SparkSession
 
 from .common import DatasetDict, GeoRule, Rule, RulesDict, ValidationSettings
 from .custom_renderers.slack_renderer import CustomSlackNotificationAction
+from .custom_renderers.teams_renderer import CustomMSTeamsRenderer
 from .output_transformations import (
     get_highest_severity_from_validation_result,
     write_validation_metadata_tables,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -7,8 +7,8 @@ from pyspark.sql import SparkSession
 from src.dq_suite.common import (
     DataQualityRulesDict,
     DatasetDict,
-    Rule,
     GeoRule,
+    Rule,
     RulesDict,
     ValidationSettings,
     get_full_table_name,

--- a/tests/test_output_transformations.py
+++ b/tests/test_output_transformations.py
@@ -1,8 +1,9 @@
 import json
-from datetime import datetime
-from unittest.mock import Mock
 from copy import deepcopy
+from datetime import datetime
 from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 from chispa import assert_df_equality
 from pyspark.sql import SparkSession
@@ -16,17 +17,17 @@ from src.dq_suite.output_transformations import (
     get_bronattribuut_data,
     get_brondataset_data,
     get_brontabel_data,
+    get_custom_validation_results,
     get_grouped_ids_per_deviating_value,
     get_highest_severity_from_validation_result,
     get_parameters_from_results,
     get_regel_data,
     get_single_expectation_afwijking_data,
     get_target_attr_for_rule,
+    get_team_data,
     get_unique_deviating_values,
     get_validatie_data,
     list_of_dicts_to_df,
-    get_custom_validation_results,
-    get_team_data,
     mask_value,
 )
 
@@ -880,7 +881,7 @@ def test_mask_value_compound_key_tuple_list():
     value = (("countryname", "Belgie"), ("id", 2))
     attr = ["countryname", "id"]
     masked = mask_value(value, attr, mask_columns=["countryname"])
-    assert masked == ( "***masked***")
+    assert masked == ("***masked***")
 
 
 def test_column_level_expectation_compound_key_masked(

--- a/tests/test_profile_generic_rules.py
+++ b/tests/test_profile_generic_rules.py
@@ -1,5 +1,5 @@
-import pytest
 import pandas as pd
+import pytest
 
 from dq_suite.profile.generic_rules import create_dq_rules
 

--- a/tests/test_profile_report_transformations.py
+++ b/tests/test_profile_report_transformations.py
@@ -1,14 +1,14 @@
-import pytest
-import pandas as pd
-from unittest.mock import patch
 from datetime import datetime
+from unittest.mock import patch
 
+import pandas as pd
+import pytest
 from pyspark.sql import SparkSession
 
 from dq_suite.profile.report_transformations import (
-    extract_top_value,
-    create_profiling_table,
     create_profiling_attributes,
+    create_profiling_table,
+    extract_top_value,
     write_profiling_metadata_to_unity,
 )
 

--- a/tests/test_profile_rule_module.py
+++ b/tests/test_profile_rule_module.py
@@ -1,16 +1,16 @@
 from dq_suite.profile.rules_module import (
     column_between_rule,
     column_compound_unique_rule,
+    column_geometry_type_rule,
     column_match_rule,
     column_not_null_rule,
     column_type_rule,
     column_unique_rule,
+    column_values_have_valid_geometry_rule,
     column_values_in_set_rule,
+    column_values_not_empty_geometry_rule,
     datetime_regex_rule,
     row_count_rule,
-    column_values_have_valid_geometry_rule,
-    column_values_not_empty_geometry_rule,
-    column_geometry_type_rule,
 )
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -18,7 +18,9 @@ from src.dq_suite.output_transformations import (
     create_validation_result_dataframe,
 )
 from src.dq_suite.validation import ValidationRunner, validate
-
+from src.dq_suite.custom_renderers.teams_renderer import (
+    CustomMSTeamsRenderer,
+)
 
 @pytest.fixture
 def validation_settings_obj():
@@ -271,6 +273,32 @@ class TestValidationRunner:
         # Now there should still be no actions in the action_list parameter
         assert isinstance(validation_runner_obj.action_list, list)
         assert len(validation_runner_obj.action_list) == 0
+
+    def test_create_action_list_with_ms_teams_webhook_uses_custom_renderer(
+        self, validation_runner_obj
+    ):
+        # Arrange
+        assert validation_runner_obj.action_list is None
+        validation_runner_obj.ms_teams_webhook = "the_ms_teams_webhook"
+ 
+        # Act
+        validation_runner_obj._create_action_list()
+ 
+        # Assert
+        action = validation_runner_obj.action_list[0]
+        assert isinstance(action, MicrosoftTeamsNotificationAction)
+        assert isinstance(action.renderer, CustomMSTeamsRenderer)
+ 
+        # Validate that the custom renderer produces an AdaptiveCard payload.
+        payload = action.renderer.render(
+            checkpoint_result=Mock(
+                success=True,
+                checkpoint_config=Mock(name="my_checkpoint"),
+                run_results={},
+            )
+        )
+        assert payload["type"] == "message"
+        assert payload["attachments"][0]["content"]["type"] == "AdaptiveCard"
 
     def test_get_or_add_checkpoint(self, validation_runner_obj):
         # TODO: mock use of ValidationDefinition for Checkpoint

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -15,15 +15,14 @@ from great_expectations.expectations import (
 from pyspark.sql import SparkSession
 from pyspark.sql.types import IntegerType, StructField, StructType
 
-from src.dq_suite.common import Rule, GeoRule, ValidationSettings
+from src.dq_suite.common import GeoRule, Rule, ValidationSettings
+from src.dq_suite.custom_renderers.teams_renderer import CustomMSTeamsRenderer
 from src.dq_suite.output_transformations import (
     create_metadata_dataframe,
     create_validation_result_dataframe,
 )
 from src.dq_suite.validation import ValidationRunner, validate
-from src.dq_suite.custom_renderers.teams_renderer import (
-    CustomMSTeamsRenderer,
-)
+
 
 @pytest.fixture
 def validation_settings_obj():
@@ -285,15 +284,15 @@ class TestValidationRunner:
         # Arrange
         assert validation_runner_obj.action_list is None
         validation_runner_obj.ms_teams_webhook = "the_ms_teams_webhook"
- 
+
         # Act
         validation_runner_obj._create_action_list()
- 
+
         # Assert
         action = validation_runner_obj.action_list[0]
         assert isinstance(action, MicrosoftTeamsNotificationAction)
         assert isinstance(action.renderer, CustomMSTeamsRenderer)
- 
+
         # Validate that the custom renderer produces an AdaptiveCard payload.
         payload = action.renderer.render(
             checkpoint_result=Mock(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -21,7 +21,9 @@ from src.dq_suite.output_transformations import (
     create_validation_result_dataframe,
 )
 from src.dq_suite.validation import ValidationRunner, validate
-
+from src.dq_suite.custom_renderers.teams_renderer import (
+    CustomMSTeamsRenderer,
+)
 
 @pytest.fixture
 def validation_settings_obj():
@@ -276,6 +278,32 @@ class TestValidationRunner:
         # Now there should still be no actions in the action_list parameter
         assert isinstance(validation_runner_obj.action_list, list)
         assert len(validation_runner_obj.action_list) == 0
+
+    def test_create_action_list_with_ms_teams_webhook_uses_custom_renderer(
+        self, validation_runner_obj
+    ):
+        # Arrange
+        assert validation_runner_obj.action_list is None
+        validation_runner_obj.ms_teams_webhook = "the_ms_teams_webhook"
+ 
+        # Act
+        validation_runner_obj._create_action_list()
+ 
+        # Assert
+        action = validation_runner_obj.action_list[0]
+        assert isinstance(action, MicrosoftTeamsNotificationAction)
+        assert isinstance(action.renderer, CustomMSTeamsRenderer)
+ 
+        # Validate that the custom renderer produces an AdaptiveCard payload.
+        payload = action.renderer.render(
+            checkpoint_result=Mock(
+                success=True,
+                checkpoint_config=Mock(name="my_checkpoint"),
+                run_results={},
+            )
+        )
+        assert payload["type"] == "message"
+        assert payload["attachments"][0]["content"]["type"] == "AdaptiveCard"
 
     def test_get_or_add_checkpoint(self, validation_runner_obj):
         # TODO: mock use of ValidationDefinition for Checkpoint


### PR DESCRIPTION
added a renderer class for Team Alerts, call the below notebook command webhook in dmt teams chat:
mswebhook ="https://default72fca1b12c2e4376a445294d801968.04.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/417be33155d140d59bd36791adbe1c19/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=pcTTdZO6GsnX3PWzyVIdaPTkyXKXohT4RJ7KkOKsGS4"

from dq_suite.validation import run_validation
run_validation(
    json_path='/Workspace/Users/r.chellaswamy@amsterdam.nl/rules.json',
    df=dfs[0], 
    spark_session=spark,
    catalog_name='dpd1_dev',
    table_name='well',
    ms_teams_webhook=mswebhook,
    notify_on='failure'
)