### PR TITLE
Added description field in Custom Renderers and rule.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.14.3] - 05-15-2026
+
+### Added
+- Added `description` field in `rule.json`.
+  ` {
+       "rule_name": "ExpectColumnValuesToBeBetween",
+        "severity" : "fatal",
+        "description": "Latitude values must be between 6 and 10000",
+        "parameters": {....`
+
+- Enabled propagation of description from rule.json into custom renderers for improved validation visibility in notifications.
+
+### Changed
+Refactored _render_validation_result in teams_renderer.py to support rule-level metadata rendering, including description.
+
+- Applied description filed of rule. json in custom renderers.
+
+### Changed
+- Updated _render_validation_result fields in teams_renderer.py.
+
 ## [0.14.2] - 05-01-2026
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # About dq-suite-amsterdam
 This repository aims to be an easy-to-use wrapper for the data quality library [Great Expectations](https://github.com/great-expectations/great_expectations) (GX). All that is needed to get started is an in-memory Spark dataframe and a set of data quality rules - specified in a JSON file [of particular formatting](dq_rules_example.json). 
 
-By default, all the validation results are written to Unity Catalog of DMT (dpd1_prd). Data Team User or Service principle (SPN) which runs jobs/notebook will be given access to DMT catalog to write results in data_quality schema. Based on the results, DQ reports can be viewed in power bi reports hosted by DMT. Alternatively, one could disallow writing to a `data_quality` schema in UC, which one has to create once per catalog via [this notebook](scripts/data_quality_tables.sql). Additionally, users can choose to get notified via Slack or Microsoft Teams.
+By default, all the validation results are written to Unity Catalog of DMT (dpd1_prd). Data Team User or Service principle (SPN) which runs jobs/notebook will be given access to DMT catalog to write results in data_quality schema. Based on the results, DQ reports can be viewed in power bi reports hosted by DMT. Alternatively, one could disallow writing to a `data_quality` schema in UC, which one has to create once per catalog via [this notebook](scripts/data_quality_tables.sql). Additionally, users can choose to get notified via Slack or Microsoft Teams with business-friendly descriptions for each data quality check.
 
 <img src="docs/wip_computer.jpg" width="20%" height="auto">
 

--- a/dq_rules_example.json
+++ b/dq_rules_example.json
@@ -16,6 +16,7 @@
                 {
                     "rule_name": "ExpectColumnValuesToBeBetween",
                     "severity" : "fatal",
+                    "description": "Latitude values must be between 6 and 10000",
                     "parameters": {
                             "column": "latitude",
                             "min_value": 6,
@@ -25,6 +26,7 @@
                 {
                     "rule_name": "ExpectColumnDistinctValuesToEqualSet",
                     "severity" : "error",
+                    "description": "Latitude values must be between 6 and 10000",
                     "parameters": {
                             "column": "latitude",
                             "value_set": [1, 2]
@@ -42,6 +44,7 @@
                 {
                     "rule_name": "ExpectColumnValuesToNotBeNull",
                     "severity" : "warning",
+                    "description": "Checks that the value is always provided",
                     "parameters": {
                             "column": "containertype"
                         }

--- a/src/dq_suite/common.py
+++ b/src/dq_suite/common.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Literal
+from typing import Any, Dict, List, Literal
 
 from delta.tables import *
 from great_expectations.core.result_format import ResultFormat
@@ -22,6 +22,9 @@ class Rule:
     ] | None = None  # Indicates the impact level of a rule if it fails.
     # evaluating the expectation
     norm: int | None = None  # TODO/check: what is the meaning of this field? Add documentation.
+    description: str | None = (
+        None  # Natural language description for business stakeholders
+    )
 
     def __post_init__(self):
         if not isinstance(self.rule_name, str):
@@ -43,6 +46,14 @@ class Rule:
                 "'severity' must be one of ('fatal', 'error', 'warning') or None"
             )
 
+        if not isinstance(self.description, str):
+            if self.description is not None:
+                raise TypeError("'description' should be of type str")
+
+        # Limit description to 250 characters for practical alerting purposes
+        if self.description is not None and len(self.description) > 250:
+            raise ValueError("'description' should not exceed 250 characters")
+
     def __getitem__(self, key) -> str | Dict[str, Any] | int | None:
         if key == "rule_name":
             return self.rule_name
@@ -52,6 +63,8 @@ class Rule:
             return self.norm
         elif key == "severity":
             return self.severity
+        elif key == "description":
+            return self.description
         raise KeyError(key)
 
 

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -44,7 +44,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
         self, result: ExpectationValidationResult
     ) -> str:
         expectation_metadata = result["expectation_config"]["meta"]
-        expectation_name = expectation_metadata["expectation_name"]
+        expectation_name = expectation_metadata["rule"]
         description = expectation_metadata.get("description", None)
         results = result.result
 
@@ -79,7 +79,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
             if partial_unexpected_list is not None:
                 partial_unexpected_list = partial_unexpected_list[:3]
             return f"""
-    \n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_name}`    *Description*:`{description_text}`\n\n
+    \n *Column*: `{expectation_metadata['column']}`    *Expectation*: `{expectation_name}`    *Description*:`{description_text}`\n\n
     :information_source: Details:
     *Sample unexpected values*:  ```{partial_unexpected_list}```\n
     *Unexpected / total count*: {results.get('unexpected_count', None)} / {results.get('element_count', 0)}\n

--- a/src/dq_suite/custom_renderers/slack_renderer.py
+++ b/src/dq_suite/custom_renderers/slack_renderer.py
@@ -45,7 +45,13 @@ class CustomSlackNotificationAction(SlackNotificationAction):
     ) -> str:
         expectation_metadata = result["expectation_config"]["meta"]
         expectation_name = expectation_metadata["expectation_name"]
+        description = expectation_metadata.get("description", None)
         results = result.result
+
+        # Create description text block if available
+        description_text = ""
+        if description:
+            description_text = f"\n *Check Description*: {description}\n"
 
         # Output for Set-type expectations is differently structured
         # TODO: refactor this output more neatly into a function
@@ -73,7 +79,7 @@ class CustomSlackNotificationAction(SlackNotificationAction):
             if partial_unexpected_list is not None:
                 partial_unexpected_list = partial_unexpected_list[:3]
             return f"""
-    \n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_name}`\n\n
+    \n *Column*: `{expectation_metadata['column_name']}`    *Expectation*: `{expectation_name}`    *Description*:`{description_text}`\n\n
     :information_source: Details:
     *Sample unexpected values*:  ```{partial_unexpected_list}```\n
     *Unexpected / total count*: {results.get('unexpected_count', None)} / {results.get('element_count', 0)}\n

--- a/src/dq_suite/custom_renderers/teams_renderer.py
+++ b/src/dq_suite/custom_renderers/teams_renderer.py
@@ -1,5 +1,4 @@
-from typing import TYPE_CHECKING
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from great_expectations.core import RunIdentifier
 from great_expectations.render.renderer.microsoft_teams_renderer import (

--- a/src/dq_suite/custom_renderers/teams_renderer.py
+++ b/src/dq_suite/custom_renderers/teams_renderer.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+from typing import Any
 
 from great_expectations.core import RunIdentifier
 from great_expectations.render.renderer.microsoft_teams_renderer import (
@@ -7,12 +8,28 @@ from great_expectations.render.renderer.microsoft_teams_renderer import (
 
 if TYPE_CHECKING:
     from great_expectations.checkpoint.checkpoint import CheckpointResult
-    from great_expectations.core.expectation_validation_result import (
-        ExpectationSuiteValidationResult,
-    )
     from great_expectations.data_context.types.resource_identifiers import (
         ValidationResultIdentifier,
     )
+
+
+def _extract_common_fields(result) -> dict[str, Any]:
+    config = result.expectation_config
+    meta = config.meta or {}
+    kwargs = config.kwargs or {}
+    print("meta: ", meta)
+    return {
+        "Rule Name": meta.get("rule"),
+        "Rule Description": meta.get("description"),
+        "Rule Column(s)": (
+            kwargs.get("column_list")
+            or kwargs.get("column_set")
+            or meta.get("column")
+        ),
+        "Result Value": result.result.get("observed_value")
+        if result.result
+        else None,
+    }
 
 
 class CustomMSTeamsRenderer(MicrosoftTeamsRenderer):
@@ -46,16 +63,33 @@ class CustomMSTeamsRenderer(MicrosoftTeamsRenderer):
         validation_result: "ExpectationSuiteValidationResult",
         validation_result_suite_identifier: "ValidationResultIdentifier",
     ) -> list[dict[str, str]]:
-        return [
-            self._render_status(validation_result=validation_result),
-            self._render_asset_name(validation_result=validation_result),
-            self._render_suite_name(validation_result=validation_result),
-            self._render_run_name(
-                validation_result_suite_identifier=validation_result_suite_identifier
-            ),
-            self._render_batch_id(validation_result=validation_result),
-            self._render_summary(validation_result=validation_result),
+        blocks = [
+            self._render_status(validation_result),
+            self._render_asset_name(validation_result),
+            self._render_suite_name(validation_result),
+            self._render_run_name(validation_result_suite_identifier),
+            self._render_batch_id(validation_result),
         ]
+
+        def add_block(key, value):
+            if value is not None:
+                blocks.append(
+                    self._render_validation_result_element(key, value)
+                )
+
+        for result in validation_result.results:
+            print(result)
+            if result.success:
+                continue
+
+            fields = _extract_common_fields(result)
+
+            for key, value in fields.items():
+                add_block(key, value)
+
+        blocks.append(self._render_summary(validation_result))
+
+        return blocks
 
     def _build_payload(
         self,
@@ -65,7 +99,6 @@ class CustomMSTeamsRenderer(MicrosoftTeamsRenderer):
     ) -> dict:
         checkpoint_name = checkpoint_result.checkpoint_config.name
         status = "Success !!!" if checkpoint_result.success else "Failure :("
-
         title_block = {
             "type": "TextBlock",
             "size": "Large",

--- a/src/dq_suite/output_transformations.py
+++ b/src/dq_suite/output_transformations.py
@@ -130,6 +130,7 @@ def merge_parameters(exp_cfg: dict) -> dict:
 
     if "meta" in exp_cfg and exp_cfg["meta"] is not None:
         parameters.update(copy.deepcopy(exp_cfg["meta"]))
+        parameters.pop("description", None)
     if "kwargs" in exp_cfg and exp_cfg["kwargs"] is not None:
         kw = copy.deepcopy(exp_cfg["kwargs"])
         for drop_key in ("batch_id", "column", "unexpected_rows_query"):

--- a/src/dq_suite/validation.py
+++ b/src/dq_suite/validation.py
@@ -159,11 +159,13 @@ class ValidationRunner:
             validation_rule["parameters"]
         )
         column_name = gx_expectation_parameters.get("column", None)
+        description = getattr(validation_rule, "description", None)
 
         gx_expectation_parameters["meta"] = {
             "table": table_name,
             "column": column_name,
             "rule": gx_expectation_name,
+            "description": description,
         }
         return gx_expectation_class(**gx_expectation_parameters)
 

--- a/src/dq_suite/validation_input.py
+++ b/src/dq_suite/validation_input.py
@@ -156,6 +156,15 @@ def validate_rule(rule: dict) -> None:
                 f"Allowed values: {sorted(allowed_severities)}"
             )
 
+    # Validate optional 'description' field
+    if "description" in rule:
+        if not isinstance(rule["description"], str):
+            raise TypeError(f"In {rule}, 'description' should be of type 'str'")
+        if len(rule["description"]) > 250:
+            raise ValueError(
+                f"In {rule}, 'description' should not exceed 250 characters (current: {len(rule['description'])})"
+            )
+
 
 def get_data_quality_rules_dict(file_path: str) -> DataQualityRulesDict:
     dq_rules_json_string = read_data_quality_rules_from_json(

--- a/tests/test_data/dq_rules.json
+++ b/tests/test_data/dq_rules.json
@@ -16,6 +16,7 @@
                 {
                     "rule_name": "ExpectColumnDistinctValuesToEqualSet",
                     "severity" : "fatal",
+                    "description": "The column should only contain values 1, 2, or 3",
                     "parameters": {
                             "column": "the_column",
                             "value_set": [1, 2, 3]

--- a/tests/test_validation_input.py
+++ b/tests/test_validation_input.py
@@ -335,6 +335,31 @@ class TestValidateRule:
                 }
             )
 
+    def test_validate_rule_with_non_string_description_raises_type_error(
+        self,
+    ):
+        with pytest.raises(TypeError, match="'description' should be of type 'str'"):
+            validate_rule(
+                rule={
+                    "rule_name": "TheRule",
+                    "parameters": {"some_key": "some_value"},
+                    "description": 123,
+                }
+            )
+
+    def test_validate_rule_with_long_description_raises_value_error(
+        self,
+    ):
+        long_description = "x" * 251  # Exceeds 250 character limit
+        with pytest.raises(ValueError, match="'description' should not exceed 250 characters"):
+            validate_rule(
+                rule={
+                    "rule_name": "TheRule",
+                    "parameters": {"some_key": "some_value"},
+                    "description": long_description,
+                }
+            )
+
     def test_validate_rule_works_as_expected(
         self,
     ):
@@ -343,9 +368,19 @@ class TestValidateRule:
                 "rule_name": "TheRule",
                 "parameters": {"some_key": "some_value"},
                 "severity": "fatal",
+                "description": "This is a business-friendly description",
             }
         )
 
+    def test_description_field_is_parsed(self, real_json_file_path):
+        dq_rules = get_data_quality_rules_dict(real_json_file_path)
+
+        first_table = dq_rules["tables"][0]
+        first_rule = first_table["rules"][0]
+
+        assert "description" in first_rule
+        assert isinstance(first_rule["description"], str)
+        assert len(first_rule["description"]) <= 250
 
 @pytest.mark.usefixtures("real_json_file_invalid_formatting_path")
 @pytest.mark.usefixtures("real_json_file_path")


### PR DESCRIPTION
- Add `description` field to rule.json
- Propagate rule description into custom renderers (Slack & Teams)
- Improve Teams Adaptive Card output with rule-level visibility